### PR TITLE
chore: agregar .github/reports/ al .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ desktop.ini
 docs/
 nexenv.docs/
 
+# Reportes internos generados por agentes
+.github/reports/
+
 # Archivos de configuracion de Nexenv (los generara la app)
 *.nexenv
 *.nexenv-team


### PR DESCRIPTION
Añade la carpeta .github/reports/ al .gitignore para excluir reportes internos del tracking.