### PR TITLE
chore: agregar egg-info al gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ coverage/
 
 # Nexenv (generado automaticamente)
 .nexenv/
+
+# Python build artifacts
+*.egg-info/


### PR DESCRIPTION
## Cambios

- Agregar `*.egg-info/` al `.gitignore` para excluir artefactos de build de Python