### PR TITLE
chore: agregar signing keys al gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Signing keys
+~/
+
 # Dependencias
 node_modules/
 .pnp


### PR DESCRIPTION
Agrega exclusion de signing keys (~/) en .gitignore para evitar trackear claves locales.