### PR TITLE
fix: numeric version for MSI compatibility

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Nexenv",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "identifier": "dev.delixon.nexenv",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Cambia la version en tauri.conf.json de 0.1.0-beta.1 a 0.1.0 para que el generador MSI (WiX) acepte la version. MSI solo soporta versiones numericas.