### PR TITLE
security: reject control/bidi chars + remove env/printenv (H-4, L-3)

### DIFF
--- a/src-tauri/src/core/runtime/scripts.rs
+++ b/src-tauri/src/core/runtime/scripts.rs
@@ -77,11 +77,17 @@ const ALLOWED_EXECUTABLES: &[&str] = &[
     // Version managers
     "nvm", "fnm", "pyenv", "rustup",
     // Generic dev
-    "echo", "cat", "ls", "pwd", "env", "printenv", "which", "true",
+    "echo", "cat", "ls", "pwd", "which", "true",
 ];
 
 /// Shell metacaracteres que permiten encadenar comandos arbitrarios.
 const DANGEROUS_CHARS: &[char] = &['|', '`', '$', '(', ')', ';', '&', '<', '>'];
+
+/// Chars Unicode de formato bidireccional que permiten ofuscar comandos visualmente.
+/// U+202A..U+202E (embeddings/overrides) y U+2066..U+2069 (isolates).
+fn is_bidi_format_char(c: char) -> bool {
+    matches!(c as u32, 0x202A..=0x202E | 0x2066..=0x2069)
+}
 
 fn validate_script_command(command: &str) -> Result<(), NexenvError> {
     if command.len() > 500 {
@@ -94,6 +100,16 @@ fn validate_script_command(command: &str) -> Result<(), NexenvError> {
         return Err(NexenvError::InvalidConfig(
             "Comando vacio".to_string(),
         ));
+    }
+
+    // Rechazar control chars (newline, tab, null, BEL, ESC, etc.) y bidi overrides.
+    for ch in command.chars() {
+        if ch.is_control() || is_bidi_format_char(ch) {
+            return Err(NexenvError::InvalidConfig(format!(
+                "Comando contiene caracter de control no permitido: {:?}",
+                ch
+            )));
+        }
     }
 
     // Rechazar metacaracteres de shell que permiten inyección
@@ -235,5 +251,29 @@ mod tests {
     fn test_validate_script_command_empty() {
         assert!(validate_script_command("").is_err());
         assert!(validate_script_command("  ").is_err());
+    }
+
+    #[test]
+    fn test_validate_script_command_rejects_control_chars() {
+        assert!(validate_script_command("npm run dev\nrm -rf /").is_err());
+        assert!(validate_script_command("npm run dev\r\nevil").is_err());
+        assert!(validate_script_command("npm run\tdev").is_err());
+        assert!(validate_script_command("npm run dev\0evil").is_err());
+        assert!(validate_script_command("npm run dev\x07").is_err());
+        assert!(validate_script_command("npm run dev\x1b[31m").is_err());
+    }
+
+    #[test]
+    fn test_validate_script_command_rejects_bidi_override() {
+        assert!(validate_script_command("npm run \u{202E}dev").is_err());
+        assert!(validate_script_command("npm run \u{202D}dev").is_err());
+        assert!(validate_script_command("npm run \u{2066}dev").is_err());
+    }
+
+    #[test]
+    fn test_validate_script_command_blocks_env_printenv() {
+        assert!(validate_script_command("env").is_err());
+        assert!(validate_script_command("env FOO=bar").is_err());
+        assert!(validate_script_command("printenv PATH").is_err());
     }
 }


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 1/7.

### H-4 — Newline/bidi bypass en validacion de scripts
`validate_script_command` ahora rechaza:
- Control chars (`\n`, `\r`, `\t`, `\0`, BEL, ESC, ...).
- Chars Unicode de formato bidi (U+202A..U+202E, U+2066..U+2069) que
  permiten invertir visualmente el comando.

Esto cierra el bypass donde un comando permitido podia contener un
newline seguido de comando arbitrario, saltandose el blacklist.

### L-3 — Remover env/printenv del allowlist
`env` y `printenv` expondrian variables de entorno del proceso (incluido
cualquier secret en env vars) sin caso legitimo en scripts de proyecto.
Leer env vars se hace desde Rust con \`std::env::var\`.

## Tests
Nuevos:
- \`test_validate_script_command_rejects_control_chars\` (\n, \r, \t, \0, BEL, ESC)
- \`test_validate_script_command_rejects_bidi_override\` (U+202E, U+202D, U+2066)
- \`test_validate_script_command_blocks_env_printenv\`

Resultado local: **13/13 tests OK**.

## Referencias
- Issue delixon-labs/delixon-nexenv#45 (H-4)
- Issue delixon-labs/nexenv-core#29 (L-3)