### PR TITLE
fix: clippy lints promovidos a error en rust 1.94/1.95

### DIFF
--- a/src-tauri/src/core/analysis/detection.rs
+++ b/src-tauri/src/core/analysis/detection.rs
@@ -83,10 +83,10 @@ pub fn detect_stack(project_path: &str) -> Result<DetectedStack, NexenvError> {
                     if let Some(obj) = dep_obj.as_object() {
                         for key in obj.keys() {
                             match key.as_str() {
-                                "react" | "react-dom" => {
-                                    if !detected_tags.contains(&"react".to_string()) {
-                                        detected_tags.push("react".to_string());
-                                    }
+                                "react" | "react-dom"
+                                    if !detected_tags.contains(&"react".to_string()) =>
+                                {
+                                    detected_tags.push("react".to_string());
                                 }
                                 "next" => detected_tags.push("nextjs".to_string()),
                                 "vue" => detected_tags.push("vue".to_string()),

--- a/src-tauri/src/core/store/sqlite_store.rs
+++ b/src-tauri/src/core/store/sqlite_store.rs
@@ -470,7 +470,7 @@ mod tests {
         let proj = make_project("crud");
 
         // Save
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         // List
         let projects = store.list_projects().unwrap();
@@ -483,7 +483,7 @@ mod tests {
         // Update (save all)
         let mut updated = proj.clone();
         updated.name = "Updated".to_string();
-        store.save_projects(&[updated.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&updated)).unwrap();
         let projects = store.list_projects().unwrap();
         assert_eq!(projects[0].name, "Updated");
 
@@ -515,7 +515,7 @@ mod tests {
     fn test_notes_crud() {
         let store = make_store();
         let proj = make_project("notes");
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         // Add
         let note = store.add_note(&proj.id, "Test note").unwrap();
@@ -536,7 +536,7 @@ mod tests {
     fn test_env_vars_crud() {
         let store = make_store();
         let proj = make_project("env");
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         let mut vars = HashMap::new();
         vars.insert("API_KEY".to_string(), "secret".to_string());
@@ -556,7 +556,7 @@ mod tests {
     fn test_cascade_delete() {
         let store = make_store();
         let proj = make_project("cascade");
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         // Add env vars and notes
         let mut vars = HashMap::new();

--- a/src-tauri/src/core/workspace/scaffold.rs
+++ b/src-tauri/src/core/workspace/scaffold.rs
@@ -600,7 +600,7 @@ mod tests {
             ..basic_config()
         };
         let all_techs = catalog::load_all_technologies();
-        let compose = generate_docker_compose(&config, &all_techs);
+        let compose = generate_docker_compose(&config, all_techs);
         assert!(compose.contains("postgresql"));
         assert!(compose.contains("services:"));
     }
@@ -609,7 +609,7 @@ mod tests {
     fn test_generate_docker_compose_no_db() {
         let config = basic_config();
         let all_techs = catalog::load_all_technologies();
-        let compose = generate_docker_compose(&config, &all_techs);
+        let compose = generate_docker_compose(&config, all_techs);
         assert!(compose.is_empty());
     }
 


### PR DESCRIPTION
## Resumen

El CI de develop se puso rojo tras mergear #81: rust 1.94/1.95 promovio varios lints clippy a error con \`-D warnings\`.

Fixes aplicados:
- \`detection.rs\`: \`collapsible_match\` → match guard.
- \`sqlite_store.rs\`: \`cloned_ref_to_slice_refs\` (x4) → \`std::slice::from_ref\`.
- \`scaffold.rs\`: \`needless_borrow\` (x2) en llamadas de test.

## Verificacion
- \`cargo clippy --all-targets -- -D warnings\` → pasa limpio.
- \`cargo test --lib\` → 142/142 OK.

Solo lints, sin cambios de comportamiento.