### PR TITLE
security: pin github actions a SHA + scaffold constants (H-3, H-7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -27,16 +27,18 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -59,12 +59,13 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           components: clippy
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 
@@ -41,7 +43,7 @@ jobs:
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: |
@@ -56,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         run: |
@@ -64,16 +66,18 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 
@@ -89,7 +93,7 @@ jobs:
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: |
@@ -104,19 +108,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 
@@ -132,7 +138,7 @@ jobs:
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: |

--- a/src-tauri/src/core/workspace/mod.rs
+++ b/src-tauri/src/core/workspace/mod.rs
@@ -1,2 +1,3 @@
 pub mod scaffold;
+mod scaffold_constants;
 pub mod vscode;

--- a/src-tauri/src/core/workspace/scaffold.rs
+++ b/src-tauri/src/core/workspace/scaffold.rs
@@ -9,6 +9,10 @@ use crate::core::models::project::{Project, ProjectStatus, RuntimeConfig};
 use crate::core::rules;
 use crate::core::store;
 use crate::core::utils::fs::ensure_dir;
+use crate::core::workspace::scaffold_constants::{
+    ACTIONS_CHECKOUT_SHA, ACTIONS_CHECKOUT_VERSION, ACTIONS_SETUP_NODE_SHA,
+    ACTIONS_SETUP_NODE_VERSION, ACTIONS_SETUP_PYTHON_SHA, ACTIONS_SETUP_PYTHON_VERSION,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -383,8 +387,8 @@ fn generate_ci_workflow(config: &ScaffoldConfig) -> String {
             "  build:".to_string(),
             "    runs-on: ubuntu-latest".to_string(),
             "    steps:".to_string(),
-            "      - uses: actions/checkout@v4".to_string(),
-            "      - uses: actions/setup-node@v4".to_string(),
+            format!("      - uses: actions/checkout@{ACTIONS_CHECKOUT_SHA} # {ACTIONS_CHECKOUT_VERSION}"),
+            format!("      - uses: actions/setup-node@{ACTIONS_SETUP_NODE_SHA} # {ACTIONS_SETUP_NODE_VERSION}"),
             "        with:".to_string(),
             "          node-version: 20".to_string(),
             "          cache: npm".to_string(),
@@ -403,8 +407,8 @@ fn generate_ci_workflow(config: &ScaffoldConfig) -> String {
             "  test:".to_string(),
             "    runs-on: ubuntu-latest".to_string(),
             "    steps:".to_string(),
-            "      - uses: actions/checkout@v4".to_string(),
-            "      - uses: actions/setup-python@v5".to_string(),
+            format!("      - uses: actions/checkout@{ACTIONS_CHECKOUT_SHA} # {ACTIONS_CHECKOUT_VERSION}"),
+            format!("      - uses: actions/setup-python@{ACTIONS_SETUP_PYTHON_SHA} # {ACTIONS_SETUP_PYTHON_VERSION}"),
             "        with:".to_string(),
             "          python-version: '3.12'".to_string(),
             "      - run: pip install -r requirements.txt".to_string(),

--- a/src-tauri/src/core/workspace/scaffold_constants.rs
+++ b/src-tauri/src/core/workspace/scaffold_constants.rs
@@ -1,0 +1,13 @@
+//! SHAs pineados para workflows generados por scaffold.
+//!
+//! Se mantienen sincronizados con los workflows del propio repo
+//! delixon-nexenv (.github/workflows/*.yml) via dependabot.
+
+pub const ACTIONS_CHECKOUT_SHA: &str = "34e114876b0b11c390a56381ad16ebd13914f8d5";
+pub const ACTIONS_CHECKOUT_VERSION: &str = "v4.3.1";
+
+pub const ACTIONS_SETUP_NODE_SHA: &str = "49933ea5288caeca8642d1e84afbd3f7d6820020";
+pub const ACTIONS_SETUP_NODE_VERSION: &str = "v4.4.0";
+
+pub const ACTIONS_SETUP_PYTHON_SHA: &str = "a26af69be951a213d495a4c3e4e4022e16d87065";
+pub const ACTIONS_SETUP_PYTHON_VERSION: &str = "v5.6.0";


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 2/7.

### H-3 — SHA pinning en workflows
Todas las GitHub Actions ahora estan pineadas a SHA fijo (inmutable) en lugar de tags movibles. Esto cierra la ventana de compromise donde un atacante podria reapuntar un tag (\`@v4\`) a un commit malicioso y pipelines descargarian el nuevo codigo sin que nadie lo note.

Workflows actualizados:
- \`.github/workflows/ci.yml\`
- \`.github/workflows/build.yml\`
- \`.github/workflows/release.yml\`
- \`.github/workflows/npm-publish.yml\`

SHAs ancladas (con comentario \`# vX.Y.Z\` para legibilidad):
- \`actions/checkout\` v4.3.1 → \`34e1148...\`
- \`actions/setup-node\` v4.4.0 → \`49933ea...\`
- \`dtolnay/rust-toolchain\` v1 → \`e97e2d8...\` + \`toolchain: stable\`
- \`swatinem/rust-cache\` v2.9.1 → \`c193711...\`
- \`softprops/action-gh-release\` v2.6.2 → \`3bb1273...\`

### H-7 — Scaffold con SHA pinning
El scaffold generaba CI workflows con \`actions/checkout@v4\` hardcodeado (un proyecto nuevo heredaba el problema). Ahora lee de \`scaffold_constants.rs\`, que mantiene los mismos SHAs que los workflows de este repo. Dependabot los refresca en conjunto.

Archivos:
- \`src-tauri/src/core/workspace/scaffold_constants.rs\` (nuevo)
- \`src-tauri/src/core/workspace/scaffold.rs\` (usa constantes)
- \`src-tauri/src/core/workspace/mod.rs\` (registra modulo)

### Extra — Dependabot
\`.github/dependabot.yml\` configura update semanal para:
- \`github-actions\` (mantiene SHAs al dia, abre PR al subir SHA)
- \`cargo\` (src-tauri)
- \`npm\` (root)

Al mergear un PR de dependabot que mueva un SHA en un workflow, hay que reflejarlo tambien en \`scaffold_constants.rs\` (a futuro se puede automatizar).

## Verificacion
- \`cargo clippy --all-targets -- -D warnings\` → pasa.
- Tests de workspace: 19/19 OK.

## Referencias
- Issue #44 (H-3)
- Issue #47 (H-7)