### PR TITLE
security: license POST + key format validation (H-5, H-6)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2208,6 +2208,8 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "once_cell",
+ "regex",
  "reqwest 0.12.18",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-app = [
     "dep:tauri-plugin-dialog",
     "dep:tauri-build",
 ]
-enterprise = ["dep:reqwest"]
+enterprise = ["dep:reqwest", "dep:regex", "dep:once_cell"]
 
 [build-dependencies]
 tauri-build = { version = "=2.5.6", features = [], optional = true }
@@ -55,6 +55,8 @@ colored = "=3.0.0"
 serde_yml = "=0.0.12"
 rusqlite = { version = "=0.39.0", features = ["bundled"] }
 reqwest = { version = "=0.12.18", features = ["json"], optional = true }
+regex = { version = "=1.12.3", optional = true }
+once_cell = { version = "=1.21.4", optional = true }
 
 [dev-dependencies]
 tempfile = "=3.20.0"

--- a/src-tauri/src/enterprise/license.rs
+++ b/src-tauri/src/enterprise/license.rs
@@ -1,7 +1,37 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Deserialize;
 
 const VALIDATION_URL: &str = "https://app.delixon.dev/api/store/license/validate/";
+
+// Solo alfanumerico, guion y underscore, 8-64 chars.
+static KEY_FORMAT: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[A-Za-z0-9_-]{8,64}$").expect("regex invariante"));
+
+#[derive(Debug, thiserror::Error)]
+pub enum LicenseError {
+    #[error("Formato de clave invalido")]
+    InvalidFormat,
+    #[error("Error de red: {0}")]
+    Network(#[from] reqwest::Error),
+    #[error("Servidor rechazo la licencia (status {0})")]
+    Server(reqwest::StatusCode),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct LicenseInfo {
+    #[serde(default)]
+    pub valid: bool,
+    #[serde(default)]
+    pub plan: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+}
 
 fn license_key_path() -> PathBuf {
     let home = dirs::home_dir().expect("No se encontro el directorio home");
@@ -13,14 +43,34 @@ fn read_license_key() -> Option<String> {
     fs::read_to_string(path).ok().map(|s| s.trim().to_string())
 }
 
-pub async fn validate_license(key: &str) -> bool {
-    let url = format!("{}?key={}", VALIDATION_URL, key);
-    let client = reqwest::Client::new();
-
-    match client.get(&url).send().await {
-        Ok(response) => response.status().is_success(),
-        Err(_) => false,
+pub fn validate_key_format(key: &str) -> Result<(), LicenseError> {
+    if KEY_FORMAT.is_match(key) {
+        Ok(())
+    } else {
+        Err(LicenseError::InvalidFormat)
     }
+}
+
+pub async fn validate_license(key: &str) -> Result<LicenseInfo, LicenseError> {
+    validate_key_format(key)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .user_agent(concat!("Nexenv/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let response = client
+        .post(VALIDATION_URL)
+        .json(&serde_json::json!({ "key": key }))
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(LicenseError::Server(response.status()));
+    }
+
+    let info: LicenseInfo = response.json().await?;
+    Ok(info)
 }
 
 pub fn is_enterprise() -> bool {
@@ -30,18 +80,19 @@ pub fn is_enterprise() -> bool {
     };
 
     let rt = tokio::runtime::Handle::try_current();
-    match rt {
-        Ok(handle) => {
-            tokio::task::block_in_place(|| handle.block_on(validate_license(&key)))
-        }
+    let result = match rt {
+        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(validate_license(&key))),
         Err(_) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(validate_license(&key))
         }
-    }
+    };
+
+    matches!(result, Ok(info) if info.valid)
 }
 
 pub fn activate_license(key: &str) -> Result<(), String> {
+    validate_key_format(key).map_err(|e| e.to_string())?;
     let path = license_key_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Error creando directorio: {}", e))?;
@@ -56,4 +107,72 @@ pub fn deactivate_license() -> Result<(), String> {
         fs::remove_file(&path).map_err(|e| format!("Error eliminando licencia: {}", e))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_format_rejects_empty() {
+        assert!(matches!(
+            validate_key_format(""),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_too_short() {
+        assert!(matches!(
+            validate_key_format("ABC123"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_too_long() {
+        let long = "a".repeat(65);
+        assert!(matches!(
+            validate_key_format(&long),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_sql_injection() {
+        assert!(matches!(
+            validate_key_format("FAKE' OR '1'='1"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_query_string_injection() {
+        assert!(matches!(
+            validate_key_format("FAKE&admin=true"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_control_chars() {
+        assert!(matches!(
+            validate_key_format("ABC\nDEF12345"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_accepts_valid() {
+        assert!(validate_key_format("abc-DEF-1234567").is_ok());
+        assert!(validate_key_format("LICENSE_KEY_2026").is_ok());
+        assert!(validate_key_format("12345678").is_ok());
+        assert!(validate_key_format(&"A".repeat(64)).is_ok());
+    }
+
+    #[test]
+    fn activate_license_rejects_invalid_format() {
+        assert!(activate_license("bad key!").is_err());
+        assert!(activate_license("").is_err());
+    }
 }


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 3/7.

### H-5 — GET con query string → POST con JSON body
La validacion de licencia enviaba la key en query string de un GET, lo que la deja registrada en:
- Logs de proxy/CDN/servidor web.
- History del browser embebido (webview).
- Metricas/analytics que capturan URLs.

Ahora se envia como \`POST /api/store/license/validate/\` con body \`{"key": "..."}\`. Body no queda en logs estandar.

### H-6 — Validacion de formato antes de enviar
\`validate_key_format\` rechaza cualquier string que no matchee \`^[A-Za-z0-9_-]{8,64}$\`. Se aplica en dos puntos:
1. Al inicio de \`validate_license\` — evita round-trip al servidor con basura y corta intentos de injection.
2. En \`activate_license\` — evita guardar keys invalidas en disco.

### Cambios internos
- \`LicenseError\` enum (InvalidFormat, Network, Server) reemplaza el \`bool\` opaco.
- \`LicenseInfo\` deserializa la respuesta (\`valid\`, \`plan\`, \`expires_at\`).
- Timeout 10s en el client.
- User-agent \`Nexenv/<CARGO_PKG_VERSION>\` — el backend puede distinguir trafico legitimo.

### Deps nuevas (solo bajo feature \`enterprise\`)
- \`regex = "=1.12.3"\`
- \`once_cell = "=1.21.4"\` (para \`Lazy<Regex>\`)

Ya estaban en el grafo transitivo, asi que Cargo.lock no mueve versiones ajenas.

## Verificacion
- \`cargo clippy --features enterprise --all-targets -- -D warnings\` → pasa.
- \`cargo test --features enterprise --lib enterprise::license\` → **8/8 OK**.
- \`cargo check\` (sin feature) → pasa.
- \`cargo check --no-default-features --bin nexenv-cli\` → pasa.

## Coordinacion con @platform
El endpoint \`LicenseValidateView\` debe aceptar:
- \`POST\` (antes era \`GET\`).
- Body JSON: \`{"key": "..."}\`.
- Respuesta 200 JSON con al menos \`{"valid": true/false}\`.

Si todavia no acepta POST, este cambio genera 405 contra el backend actual — hay que coordinar despliegue conjunto.

## Referencias
- Issue #46 (H-5, H-6)