### PR TITLE
security: validate import paths + sanitize shell launchers (M-1, M-10)

### DIFF
--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -3,6 +3,15 @@ use crate::core::store;
 use std::process::Command;
 use tauri::command;
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Rechaza paths con control chars que podrian romper parsers downstream
+/// (CMD, PowerShell, shells POSIX) o permitir inyectar args adicionales.
+fn path_has_control_chars(path: &str) -> bool {
+    path.chars().any(|c| c.is_control())
+}
+
 /// Abre una terminal en la carpeta del proyecto con el entorno correcto cargado
 #[command]
 pub async fn open_terminal(project_id: String) -> Result<(), String> {
@@ -11,6 +20,10 @@ pub async fn open_terminal(project_id: String) -> Result<(), String> {
         .iter()
         .find(|p| p.id == project_id)
         .ok_or_else(|| format!("Proyecto no encontrado: {}", project_id))?;
+
+    if path_has_control_chars(&project.path) {
+        return Err("Ruta del proyecto invalida: contiene caracteres de control".to_string());
+    }
 
     let path = std::path::Path::new(&project.path);
     if !path.exists() || !path.is_dir() {
@@ -63,22 +76,26 @@ pub async fn open_terminal(project_id: String) -> Result<(), String> {
 // --- Windows terminals ---
 
 fn try_windows_terminal(project_path: &str, env_vars: &std::collections::HashMap<String, String>) -> bool {
-    // Windows Terminal (wt.exe)
-    if which::which("wt").is_ok() {
-        let mut cmd = Command::new("wt");
-        cmd.arg("-d").arg(project_path);
-        for (k, v) in env_vars {
-            cmd.env(k, v);
-        }
-        if cmd.spawn().is_ok() {
-            return true;
-        }
+    if path_has_control_chars(project_path) || which::which("wt").is_err() {
+        return false;
     }
-    false
+    let mut cmd = Command::new("wt");
+    cmd.arg("-d").arg(project_path);
+    for (k, v) in env_vars {
+        cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd.spawn().is_ok()
 }
 
 fn try_powershell(project_path: &str, env_vars: &std::collections::HashMap<String, String>) -> bool {
-    // PowerShell
+    if path_has_control_chars(project_path) {
+        return false;
+    }
     let ps = if which::which("pwsh").is_ok() {
         "pwsh"
     } else if which::which("powershell").is_ok() {
@@ -87,23 +104,49 @@ fn try_powershell(project_path: &str, env_vars: &std::collections::HashMap<Strin
         return false;
     };
 
-    let safe_path = project_path.replace('\'', "''");
+    // Usamos `start /D <path>` para que la nueva ventana de PowerShell
+    // arranque en el directorio correcto sin pasar el path dentro de un
+    // comando -Command (evita cualquier riesgo de inyeccion via el path).
     let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg("start").arg(ps).arg("-NoExit").arg("-Command")
-        .arg(format!("Set-Location '{}'", safe_path));
+    cmd.arg("/c")
+        .arg("start")
+        .arg("")
+        .arg("/D")
+        .arg(project_path)
+        .arg(ps)
+        .arg("-NoExit");
     for (k, v) in env_vars {
         cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
     cmd.spawn().is_ok()
 }
 
 fn try_cmd(project_path: &str, env_vars: &std::collections::HashMap<String, String>) -> bool {
-    let safe_path = project_path.replace('"', "");
+    if path_has_control_chars(project_path) {
+        return false;
+    }
+    // `start /D <path> cmd /K` abre una ventana nueva de cmd en el dir
+    // sin pasar el path por una cadena concatenada.
     let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg("start").arg("cmd").arg("/k")
-        .arg(format!("cd /d \"{}\"", safe_path));
+    cmd.arg("/c")
+        .arg("start")
+        .arg("")
+        .arg("/D")
+        .arg(project_path)
+        .arg("cmd")
+        .arg("/K");
     for (k, v) in env_vars {
         cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
     cmd.spawn().is_ok()
 }
@@ -208,12 +251,12 @@ fn try_linux_terminals(project_path: &str, env_vars: &std::collections::HashMap<
         }
     }
 
-    // xterm fallback
+    // xterm fallback: xterm no tiene --working-directory, pero hereda el
+    // cwd del proceso padre — seteamos cwd via Command::current_dir para
+    // evitar concatenar el path en un string de shell.
     if which::which("xterm").is_ok() {
-        let safe_path = project_path.replace('\'', "'\\''");
-        let shell_cmd = format!("cd '{}' && exec $SHELL", safe_path);
         let mut cmd = Command::new("xterm");
-        cmd.arg("-e").arg("sh").arg("-c").arg(&shell_cmd);
+        cmd.current_dir(project_path);
         for (k, v) in env_vars {
             cmd.env(k, v);
         }

--- a/src-tauri/src/core/project/portable.rs
+++ b/src-tauri/src/core/project/portable.rs
@@ -1,3 +1,5 @@
+use std::path::{Component, Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
 
 use crate::core::error::NexenvError;
@@ -59,8 +61,57 @@ pub fn export_project(project_id: &str) -> Result<String, NexenvError> {
     Ok(json)
 }
 
+/// Valida el target_path de un import contra path traversal, control chars
+/// y paths relativos. Devuelve el path normalizado.
+///
+/// No canonicaliza (el path puede no existir todavia), pero rechaza:
+/// - Strings vacios.
+/// - Paths relativos (debe ser absoluto).
+/// - Control chars (\n, \r, \0, etc.) que pueden romper parsers downstream.
+/// - Cualquier componente `..` (ParentDir) — corta traversal explicito.
+pub fn validate_target_path(target: &str) -> Result<PathBuf, NexenvError> {
+    if target.trim().is_empty() {
+        return Err(NexenvError::InvalidPath(
+            "El path de destino no puede estar vacio".to_string(),
+        ));
+    }
+
+    if target.chars().any(|c| c.is_control()) {
+        return Err(NexenvError::InvalidPath(
+            "El path contiene caracteres de control".to_string(),
+        ));
+    }
+
+    let path = PathBuf::from(target);
+
+    if !path.is_absolute() {
+        return Err(NexenvError::InvalidPath(format!(
+            "El path debe ser absoluto: {}",
+            target
+        )));
+    }
+
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(NexenvError::InvalidPath(format!(
+            "El path contiene traversal ('..'): {}",
+            target
+        )));
+    }
+
+    // Si el path existe, canonicalizar para resolver symlinks y comparar
+    // contra cualquier constraint futuro. Si no existe (caso normal en
+    // un import a carpeta nueva), devolvemos el path tal cual.
+    match Path::new(&path).canonicalize() {
+        Ok(resolved) => Ok(resolved),
+        Err(_) => Ok(path),
+    }
+}
+
 /// Importa un proyecto desde JSON portable (.nexenv)
 pub fn import_project(json: &str, target_path: &str) -> Result<Project, NexenvError> {
+    let validated = validate_target_path(target_path)?;
+    let target_path = validated.to_string_lossy().to_string();
+
     let export: NexenvExport = serde_json::from_str(json)?;
 
     let now = chrono::Utc::now().to_rfc3339();
@@ -102,7 +153,7 @@ pub fn import_project(json: &str, target_path: &str) -> Result<Project, NexenvEr
 
     // Restaurar manifest si viene en el export
     if let Some(m) = export.manifest {
-        let _ = manifest::save_manifest(target_path, &m);
+        let _ = manifest::save_manifest(&target_path, &m);
     }
 
     Ok(project)
@@ -115,11 +166,18 @@ mod tests {
     use crate::core::store;
     use serial_test::serial;
 
+    fn temp_path(suffix: &str) -> String {
+        std::env::temp_dir()
+            .join(format!("nexenv-portable-test-{}", suffix))
+            .to_string_lossy()
+            .to_string()
+    }
+
     fn make_test_project(suffix: &str) -> Project {
         Project {
             id: format!("test-portable-{}", suffix),
             name: format!("Portable Test {}", suffix),
-            path: format!("/tmp/nexenv-portable-test-{}", suffix),
+            path: temp_path(suffix),
             description: Some("portable test".to_string()),
             runtimes: vec![RuntimeConfig {
                 runtime: "node".to_string(),
@@ -173,19 +231,19 @@ mod tests {
         let json = export_project(&proj.id).expect("export should succeed");
 
         // Import at a different path
-        let import_path = "/tmp/nexenv-portable-import-roundtrip";
-        cleanup_by_path(import_path);
-        let imported = import_project(&json, import_path).expect("import should succeed");
+        let import_path = temp_path("import-roundtrip");
+        cleanup_by_path(&import_path);
+        let imported = import_project(&json, &import_path).expect("import should succeed");
 
         assert_eq!(imported.name, proj.name);
-        assert_eq!(imported.path, import_path);
+        assert!(imported.path.ends_with("nexenv-portable-test-import-roundtrip"));
         assert_eq!(imported.tags, proj.tags);
         assert_ne!(imported.id, proj.id, "imported project should get a new id");
 
         // Cleanup
         cleanup_project(&proj_id);
         cleanup_project(&imported.id);
-        cleanup_by_path(import_path);
+        cleanup_by_path(&import_path);
     }
 
     #[test]
@@ -199,8 +257,80 @@ mod tests {
     #[test]
     fn test_import_invalid_json() {
         crate::core::store::init_test_store();
-        let result = import_project("this is not json", "/tmp/nexenv-invalid");
+        let path = temp_path("invalid");
+        let result = import_project("this is not json", &path);
         assert!(result.is_err(), "importing invalid JSON should error");
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_empty() {
+        assert!(matches!(
+            validate_target_path(""),
+            Err(NexenvError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            validate_target_path("   "),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_control_chars() {
+        assert!(matches!(
+            validate_target_path("/tmp/evil\n/etc/passwd"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            validate_target_path("/tmp/evil\0null"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_relative() {
+        assert!(matches!(
+            validate_target_path("relative/path"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            validate_target_path("./foo"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_traversal() {
+        #[cfg(unix)]
+        let evil = "/tmp/../etc/passwd";
+        #[cfg(windows)]
+        let evil = r"C:\tmp\..\Windows\System32";
+        assert!(matches!(
+            validate_target_path(evil),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_accepts_valid() {
+        let valid = temp_path("valid-path-check");
+        assert!(validate_target_path(&valid).is_ok());
+    }
+
+    #[test]
+    fn test_import_rejects_invalid_path() {
+        crate::core::store::init_test_store();
+        let bogus_json = serde_json::json!({
+            "version": "1",
+            "exportedAt": "2026-01-01T00:00:00Z",
+            "project": {
+                "name": "x", "runtimes": [], "tags": [], "envKeys": []
+            }
+        })
+        .to_string();
+        // relative path
+        assert!(import_project(&bogus_json, "relative/path").is_err());
+        // control char
+        assert!(import_project(&bogus_json, "/tmp/evil\nname").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 4/7.

### M-1 — Path traversal en import_project
\`validate_target_path\` valida el \`target_path\` recibido en \`import_project\` antes de tocar el store o el filesystem:
- Rechaza strings vacios.
- Rechaza control chars (\`\n\`, \`\r\`, \`\0\`, etc.) — evita romper parsers downstream e inyectar newlines en logs.
- Exige path absoluto — corta \`../../etc/passwd\`, \`foo/..\`, etc.
- Rechaza cualquier componente \`..\`.
- Canonicaliza si el path existe (resuelve symlinks).

Sin esto, un \`.nexenv\` malicioso podria registrar un proyecto con \`path = "../../etc"\` y que operaciones posteriores (save_manifest, delete, etc.) escribieran en lugares sensibles.

### M-10 — Windows shell launchers sin format!()
Los launchers de terminal en Windows concatenaban el \`project_path\` dentro de strings de shell (\`cd /d "{}"\` en CMD, \`Set-Location '{}'\` en PowerShell). Si el path tuviera comillas, backticks, o meta-chars de shell, se podia bypassear el escape manual.

Refactor:
- \`try_cmd\`: \`start /D <path> cmd /K\`. El path es un arg propio, CMD lo trata como dir de trabajo, sin interpolacion en ningun string.
- \`try_powershell\`: \`start /D <path> pwsh -NoExit\`. Sin \`-Command "Set-Location ..."\`.
- Las 3 funciones rechazan paths con control chars como defensa en profundidad.
- \`CREATE_NO_WINDOW\` en el \`cmd\` intermediario (evita flash de consola).
- \`xterm\` fallback en Linux: deja de construir \`sh -c "cd '...' && exec \$SHELL"\` y usa \`Command::current_dir(path)\` — el cwd se hereda sin pasar por string de shell.

### Tests
- 11/11 portable OK — nuevos tests para \`validate_target_path\` (empty, control chars, relative, traversal) e \`import_rejects_invalid_path\`.
- Tests migrados de \`/tmp\` (no absoluto en Windows) a \`std::env::temp_dir()\` para pasar en los 3 OS del CI.
- 148/148 tests totales OK.

## Referencias
- Issue #48 (M-1)
- Issue #50 (M-10)