### PR TITLE
security: restringir scope fs + cachear is_enterprise (L-4, L-5)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capabilities for Nexenv desktop app",
+  "description": "Default capabilities for Nexenv desktop app. El frontend no usa tauri_plugin_fs directamente — todo el acceso a filesystem pasa por comandos Rust, que hacen su propia validacion de paths. No se exponen permisos fs:* al frontend.",
   "windows": ["main"],
   "permissions": [
     "core:default",
@@ -12,11 +12,6 @@
         { "url": "http://localhost:*" }
       ]
     },
-    "fs:default",
-    "fs:allow-read-text-file",
-    "fs:allow-write-text-file",
-    "fs:allow-exists",
-    "fs:allow-mkdir",
     "process:default",
     "dialog:default",
     "core:window:allow-start-dragging",

--- a/src-tauri/src/enterprise/license.rs
+++ b/src-tauri/src/enterprise/license.rs
@@ -1,10 +1,15 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::RwLock;
 use std::time::Duration;
 
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
+
+// Cache del resultado de is_enterprise(). None = sin consultar aun,
+// Some(v) = ultimo resultado conocido. Se invalida en activate/deactivate.
+static ENTERPRISE_STATUS: RwLock<Option<bool>> = RwLock::new(None);
 
 const VALIDATION_URL: &str = "https://app.delixon.dev/api/store/license/validate/";
 
@@ -73,22 +78,36 @@ pub async fn validate_license(key: &str) -> Result<LicenseInfo, LicenseError> {
     Ok(info)
 }
 
-pub fn is_enterprise() -> bool {
+pub fn invalidate_enterprise_cache() {
+    if let Ok(mut guard) = ENTERPRISE_STATUS.write() {
+        *guard = None;
+    }
+}
+
+fn set_enterprise_cache(value: bool) {
+    if let Ok(mut guard) = ENTERPRISE_STATUS.write() {
+        *guard = Some(value);
+    }
+}
+
+pub async fn is_enterprise() -> bool {
+    // Cache hit: una sola pasada por la red; subsiguientes llamadas la
+    // reutilizan hasta que activate/deactivate invalide.
+    if let Some(cached) = ENTERPRISE_STATUS.read().ok().and_then(|g| *g) {
+        return cached;
+    }
+
     let key = match read_license_key() {
         Some(k) if !k.is_empty() => k,
-        _ => return false,
-    };
-
-    let rt = tokio::runtime::Handle::try_current();
-    let result = match rt {
-        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(validate_license(&key))),
-        Err(_) => {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(validate_license(&key))
+        _ => {
+            set_enterprise_cache(false);
+            return false;
         }
     };
 
-    matches!(result, Ok(info) if info.valid)
+    let valid = matches!(validate_license(&key).await, Ok(info) if info.valid);
+    set_enterprise_cache(valid);
+    valid
 }
 
 pub fn activate_license(key: &str) -> Result<(), String> {
@@ -98,6 +117,7 @@ pub fn activate_license(key: &str) -> Result<(), String> {
         fs::create_dir_all(parent).map_err(|e| format!("Error creando directorio: {}", e))?;
     }
     fs::write(&path, key).map_err(|e| format!("Error guardando licencia: {}", e))?;
+    invalidate_enterprise_cache();
     Ok(())
 }
 
@@ -106,6 +126,7 @@ pub fn deactivate_license() -> Result<(), String> {
     if path.exists() {
         fs::remove_file(&path).map_err(|e| format!("Error eliminando licencia: {}", e))?;
     }
+    invalidate_enterprise_cache();
     Ok(())
 }
 
@@ -174,5 +195,13 @@ mod tests {
     fn activate_license_rejects_invalid_format() {
         assert!(activate_license("bad key!").is_err());
         assert!(activate_license("").is_err());
+    }
+
+    #[test]
+    fn invalidate_cache_resets_status() {
+        set_enterprise_cache(true);
+        assert_eq!(*ENTERPRISE_STATUS.read().unwrap(), Some(true));
+        invalidate_enterprise_cache();
+        assert_eq!(*ENTERPRISE_STATUS.read().unwrap(), None);
     }
 }

--- a/src-tauri/src/enterprise/mod.rs
+++ b/src-tauri/src/enterprise/mod.rs
@@ -5,6 +5,6 @@ pub mod license;
 pub use license::is_enterprise;
 
 #[cfg(not(feature = "enterprise"))]
-pub fn is_enterprise() -> bool {
+pub async fn is_enterprise() -> bool {
     false
 }


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 5/7.

### L-4 — Quitar permisos fs del frontend
Audit: \`grep -r '@tauri-apps/plugin-fs' src/\` → **0 matches**. El frontend React/TS no usa \`plugin-fs\` en ningun sitio; todo el FS work pasa por comandos Rust (\`invoke(...)\`) que validan paths (ver M-1).

Los permisos \`fs:default\`, \`fs:allow-read-text-file\`, \`fs:allow-write-text-file\`, \`fs:allow-exists\`, \`fs:allow-mkdir\` en \`capabilities/default.json\` estaban abriendo un vector innecesario: un XSS en el frontend podria leer/escribir archivos arbitrarios via el plugin aunque ningun codigo legitimo lo use.

Se quitan los 5 permisos. El plugin sigue registrado en Rust (\`lib.rs:21\`) por si un comando interno del backend lo necesita, pero desde JS ya no es invocable.

### L-5 — Cache para is_enterprise + fin de block_in_place
\`is_enterprise()\` era \`fn -> bool\` y hacia \`block_in_place(|| handle.block_on(validate_license(&key)))\`:
- Un HTTP request a cada llamada (latencia + ruido de red).
- Puede deadlockear en un runtime tokio single-threaded.
- Llamarla desde una funcion async es un anti-patron (bloqueo del executor).

Ahora:
- \`is_enterprise()\` es \`async fn\`; el runtime la maneja nativamente.
- \`RwLock<Option<bool>>\` cache: primera llamada hace el HTTP, las siguientes leen del cache.
- \`invalidate_enterprise_cache()\` limpia el cache al activar/desactivar licencia, de modo que el siguiente check reevalue.

La version sin feature \`enterprise\` (\`mod.rs\`) tambien es async, para que ambas ramas tengan la misma firma.

## Verificacion
- \`cargo clippy --features enterprise --all-targets -- -D warnings\` → pasa.
- \`cargo clippy --all-targets -- -D warnings\` (sin feature) → pasa.
- \`cargo test --features enterprise --lib enterprise::license\` → **9/9 OK** (incluye test de cache).
- \`cargo test --lib\` → **148/148 OK**.

## Referencias
- Issue delixon-labs/nexenv-core#30 (L-4)
- Issue delixon-labs/delixon-nexenv#53 (L-5)