### PR TITLE
security: cargo-audit + cargo-deny en CI (M-2, L-11)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,51 @@
+name: Security audit
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Corre a las 06:00 UTC todos los lunes para detectar advisories
+    # que aparecieron sin cambio en el repo.
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: security-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: cargo audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: src-tauri
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: cargo deny
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+        with:
+          manifest-path: src-tauri/Cargo.toml
+          command: check ${{ matrix.checks }}

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -1,0 +1,44 @@
+[graph]
+targets = [
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "Zlib",
+    "MPL-2.0",
+    "OpenSSL",
+    "BSL-1.0",
+]
+confidence-threshold = 0.9
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 6/7.

### M-2 — rustls-webpki: no aplica
El audit inicial senalaba una advisory abierta en \`rustls-webpki\`. Al revisar el grafo:
\`\`\`
cargo tree --features enterprise | grep -iE "rustls|webpki"
#  rustls-pki-types v1.14.0   (solo tipos, sin verificacion real)
#  ningun otro match
\`\`\`
El TLS pasa por \`native-tls\` (hyper-tls + tokio-native-tls). La advisory no nos toca. El foco se mueve a instrumentar el CI para detectar *cualquier* advisory futura sin depender de audits manuales.

### L-11 — cargo-audit y cargo-deny en el CI
Nuevo workflow \`.github/workflows/security-audit.yml\`:
- **Triggers**: push a main/develop, PR a main/develop, y **cron semanal** (lunes 06:00 UTC) — asi las advisories nuevas se detectan sin cambio en el repo.
- **Jobs**:
  - \`cargo-audit\` (\`rustsec/audit-check@v2.0.0\`, SHA pineado) — detecta vulnerabilidades conocidas en el Cargo.lock.
  - \`cargo-deny\` con matrix: \`advisories\` y \`bans licenses sources\` corren como jobs separados para que un fallo de licencia no oculte una advisory activa. SHA pineado (\`EmbarkStudios/cargo-deny-action@v2.0.17\`).

\`src-tauri/deny.toml\`:
- \`[advisories]\`: \`yanked = "deny"\`, sin \`ignore\` (si aparece algo, hay que tratarlo).
- \`[licenses]\`: allowlist explicito (MIT, Apache-2.0 con LLVM exception, BSD-2/3, ISC, Unicode-*, MPL-2.0, OpenSSL, BSL-1.0, Zlib, CC0-1.0). Copyleft fuerte (GPL, AGPL) queda fuera.
- \`[bans]\`: \`multiple-versions = "warn"\` (tauri trae muchas duplicadas — avisar sin romper), \`wildcards = "deny"\`.
- \`[sources]\`: solo \`crates.io-index\`; \`unknown-git = "deny"\`.
- \`[graph]\`: targets x86_64-windows-msvc, x86_64-linux-gnu, x86_64 y aarch64-apple-darwin.

## Verificacion
- Local: \`cargo audit\` requiere \`cargo install cargo-audit\` — se delega al CI.
- El CI correra en el PR. Si falla por licencia desconocida o advisory, hay que ajustar \`deny.toml\` (anadir a \`licenses.allow\` o documentar en \`advisories.ignore\` con fecha de revision).

## Referencias
- Issue #49 (M-2)
- Issue #54 (L-11)