### PR TITLE
security: scaffold del auto-updater firmado (L-12)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +642,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +905,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1985,7 +2016,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2106,6 +2140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2262,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2359,6 +2400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2534,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,7 +2590,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2738,6 +2805,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3000,6 +3073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,15 +3197,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3233,10 +3320,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3247,6 +3347,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3765,7 +3892,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4014,6 +4141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4359,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5084,6 +5255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5767,6 +5947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5867,6 +6057,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,12 @@ tauri-app = [
     "dep:tauri-build",
 ]
 enterprise = ["dep:reqwest", "dep:regex", "dep:once_cell"]
+# Activar el auto-updater del installer firmado. Requiere:
+# - Keypair generado con `tauri signer generate`.
+# - Secret TAURI_SIGNING_PRIVATE_KEY en GitHub Actions.
+# - pubkey completada en tauri.conf.json.
+# - Endpoint del update manifest desplegado en delixon-platform.
+auto-updater = ["dep:tauri-plugin-updater"]
 
 [build-dependencies]
 tauri-build = { version = "=2.5.6", features = [], optional = true }
@@ -42,6 +48,7 @@ tauri-plugin-shell = { version = "=2.3.5", optional = true }
 tauri-plugin-fs = { version = "=2.5.0", optional = true }
 tauri-plugin-process = { version = "=2.3.1", optional = true }
 tauri-plugin-dialog = { version = "=2.7.0", optional = true }
+tauri-plugin-updater = { version = "=2.10.1", optional = true }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
 tokio = { version = "=1.50.0", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,11 +16,16 @@ pub fn run() {
     // Inicializar store global: SQLite con fallback a JSON
     core::store::init(init_store());
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_dialog::init());
+
+    #[cfg(feature = "auto-updater")]
+    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+
+    builder
         .invoke_handler(tauri::generate_handler![
             // Projects
             projects::list_projects,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,17 @@
       "icons/128x128@2x.png",
       "icons/icon.ico",
       "icons/icon.png"
-    ]
+    ],
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "active": false,
+      "dialog": false,
+      "endpoints": [
+        "https://app.delixon.dev/api/nexenv/update/{{target}}/{{arch}}/{{current_version}}"
+      ],
+      "pubkey": "REEMPLAZAR_CON_LA_PUBLIC_KEY_GENERADA_POR_TAURI_SIGNER"
+    }
   }
 }


### PR DESCRIPTION
## Resumen

Hardening Fase 7.6 (B) — PR 7/7 (ultimo).

### L-12 — Auto-updater de Tauri (scaffold)
Prepara la infraestructura para el auto-updater firmado **sin activarlo**. La activacion requiere pasos manuales (keypair, secrets, endpoint en el backend) que no se pueden hacer en un PR de codigo.

### Cambios
- **\`Cargo.toml\`**: \`tauri-plugin-updater = "=2.10.1"\` como dep opcional bajo nuevo feature \`auto-updater\` (off por default). Un build \`cargo build\` sin flags no compila ni descarga el plugin.
- **\`src/lib.rs\`**: registra el plugin condicionalmente con \`#[cfg(feature = "auto-updater")]\`. Sin el feature, el Builder ni siquiera ve el plugin.
- **\`tauri.conf.json\`**:
  - \`bundle.createUpdaterArtifacts = true\`: en releases firmados, Tauri genera los artefactos \`.sig\` + \`latest.json\` junto al installer.
  - \`plugins.updater.active = false\`: el plugin queda configurado pero no hace ningun check en runtime aun (la pubkey es placeholder).
  - \`plugins.updater.endpoints\`: placeholder con \`{{target}}\`/\`{{arch}}\`/\`{{current_version}}\`.
  - \`plugins.updater.pubkey\`: placeholder, se reemplaza cuando se genere la keypair real.
  - \`plugins.updater.dialog = false\`: asi el frontend puede manejar la UX en lugar del dialogo nativo.

### Que falta para activar (en otro PR, cuando esten las claves)

\`\`\`
# 1. Generar keypair (el usuario responde a un password)
npx @tauri-apps/cli signer generate -w nexenv-updater.key

# 2. Secrets en https://github.com/delixon-labs/delixon-nexenv/settings/secrets/actions
#    - TAURI_SIGNING_PRIVATE_KEY (contenido del archivo nexenv-updater.key)
#    - TAURI_SIGNING_PRIVATE_KEY_PASSWORD

# 3. Reemplazar pubkey en tauri.conf.json (plugins.updater.pubkey)
#    y activar: plugins.updater.active = true

# 4. Anadir a capabilities/default.json permissions:
#    "updater:default"

# 5. Endpoint en delixon-platform devolviendo JSON:
#    { "version": "1.0.0",
#      "pub_date": "2026-04-17T00:00:00Z",
#      "platforms": {
#        "darwin-x86_64":  { "signature": "...", "url": "https://..." },
#        "windows-x86_64": { "signature": "...", "url": "https://..." },
#        "linux-x86_64":   { "signature": "...", "url": "https://..." }
#      } }

# 6. Release builds con el feature:
#    cargo build --features auto-updater (ya esta en release.yml si se activa)

# 7. UI en el frontend: notificacion discreta "Update disponible" con
#    botones Install / Later.
\`\`\`

## Verificacion
- \`cargo check\` (sin feature) → pasa, no descarga tauri-plugin-updater.
- \`cargo check --features auto-updater\` → pasa, plugin compilado.
- \`cargo clippy --all-targets -- -D warnings\` (con y sin feature) → pasa.
- \`cargo test --lib\` → **148/148 OK**.
- El build default sigue funcionando exactamente igual que en main: ni el plugin ni el auto-check se cargan.

## Referencias
- Issue delixon-labs/nexenv-core#31 (L-12)

---

## Cierre del Bloque 7 (Hardening Fase 7.6 B)
Con este PR se completan los **7 PRs** del plan de seguridad:
- delixon-labs/delixon-nexenv#81 H-4 control/bidi chars + L-3 env/printenv
- delixon-labs/delixon-nexenv#83 H-3 SHA pinning workflows + H-7 scaffold
- delixon-labs/delixon-nexenv#84 H-5 + H-6 License POST + formato
- delixon-labs/delixon-nexenv#85 M-1 path traversal + M-10 try_cmd
- delixon-labs/delixon-nexenv#86 L-4 fs scope + L-5 block_in_place
- delixon-labs/delixon-nexenv#87 M-2 + L-11 cargo-audit/deny
- **ESTE** L-12 updater scaffold

Siguiente paso tras merge a develop: 1 solo PR \`develop → main\` + alineacion de las 3 ramas al mismo hash.