### PR TITLE
Security hardening Fase 7.6 (B) — 12 fixes + 1 hotfix CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -27,16 +27,18 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -59,12 +59,13 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           components: clippy
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 
@@ -41,7 +43,7 @@ jobs:
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: |
@@ -56,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         run: |
@@ -64,16 +66,18 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 
@@ -89,7 +93,7 @@ jobs:
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: |
@@ -104,19 +108,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 
@@ -132,7 +138,7 @@ jobs:
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,51 @@
+name: Security audit
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Corre a las 06:00 UTC todos los lunes para detectar advisories
+    # que aparecieron sin cambio en el repo.
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: security-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: cargo audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: src-tauri
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: cargo deny
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+        with:
+          manifest-path: src-tauri/Cargo.toml
+          command: check ${{ matrix.checks }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2208,6 +2208,8 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "once_cell",
+ "regex",
  "reqwest 0.12.18",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +642,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +905,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1985,7 +2016,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2106,6 +2140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2262,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2359,6 +2400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2534,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,7 +2590,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2738,6 +2805,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3000,6 +3073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,15 +3197,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3233,10 +3320,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3247,6 +3347,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3765,7 +3892,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4014,6 +4141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4359,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5084,6 +5255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5767,6 +5947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5867,6 +6057,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,12 @@ tauri-app = [
     "dep:tauri-build",
 ]
 enterprise = ["dep:reqwest", "dep:regex", "dep:once_cell"]
+# Activar el auto-updater del installer firmado. Requiere:
+# - Keypair generado con `tauri signer generate`.
+# - Secret TAURI_SIGNING_PRIVATE_KEY en GitHub Actions.
+# - pubkey completada en tauri.conf.json.
+# - Endpoint del update manifest desplegado en delixon-platform.
+auto-updater = ["dep:tauri-plugin-updater"]
 
 [build-dependencies]
 tauri-build = { version = "=2.5.6", features = [], optional = true }
@@ -42,6 +48,7 @@ tauri-plugin-shell = { version = "=2.3.5", optional = true }
 tauri-plugin-fs = { version = "=2.5.0", optional = true }
 tauri-plugin-process = { version = "=2.3.1", optional = true }
 tauri-plugin-dialog = { version = "=2.7.0", optional = true }
+tauri-plugin-updater = { version = "=2.10.1", optional = true }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
 tokio = { version = "=1.50.0", features = ["full"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-app = [
     "dep:tauri-plugin-dialog",
     "dep:tauri-build",
 ]
-enterprise = ["dep:reqwest"]
+enterprise = ["dep:reqwest", "dep:regex", "dep:once_cell"]
 
 [build-dependencies]
 tauri-build = { version = "=2.5.6", features = [], optional = true }
@@ -55,6 +55,8 @@ colored = "=3.0.0"
 serde_yml = "=0.0.12"
 rusqlite = { version = "=0.39.0", features = ["bundled"] }
 reqwest = { version = "=0.12.18", features = ["json"], optional = true }
+regex = { version = "=1.12.3", optional = true }
+once_cell = { version = "=1.21.4", optional = true }
 
 [dev-dependencies]
 tempfile = "=3.20.0"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capabilities for Nexenv desktop app",
+  "description": "Default capabilities for Nexenv desktop app. El frontend no usa tauri_plugin_fs directamente — todo el acceso a filesystem pasa por comandos Rust, que hacen su propia validacion de paths. No se exponen permisos fs:* al frontend.",
   "windows": ["main"],
   "permissions": [
     "core:default",
@@ -12,11 +12,6 @@
         { "url": "http://localhost:*" }
       ]
     },
-    "fs:default",
-    "fs:allow-read-text-file",
-    "fs:allow-write-text-file",
-    "fs:allow-exists",
-    "fs:allow-mkdir",
     "process:default",
     "dialog:default",
     "core:window:allow-start-dragging",

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -1,0 +1,44 @@
+[graph]
+targets = [
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "Zlib",
+    "MPL-2.0",
+    "OpenSSL",
+    "BSL-1.0",
+]
+confidence-threshold = 0.9
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -3,6 +3,15 @@ use crate::core::store;
 use std::process::Command;
 use tauri::command;
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Rechaza paths con control chars que podrian romper parsers downstream
+/// (CMD, PowerShell, shells POSIX) o permitir inyectar args adicionales.
+fn path_has_control_chars(path: &str) -> bool {
+    path.chars().any(|c| c.is_control())
+}
+
 /// Abre una terminal en la carpeta del proyecto con el entorno correcto cargado
 #[command]
 pub async fn open_terminal(project_id: String) -> Result<(), String> {
@@ -11,6 +20,10 @@ pub async fn open_terminal(project_id: String) -> Result<(), String> {
         .iter()
         .find(|p| p.id == project_id)
         .ok_or_else(|| format!("Proyecto no encontrado: {}", project_id))?;
+
+    if path_has_control_chars(&project.path) {
+        return Err("Ruta del proyecto invalida: contiene caracteres de control".to_string());
+    }
 
     let path = std::path::Path::new(&project.path);
     if !path.exists() || !path.is_dir() {
@@ -63,22 +76,26 @@ pub async fn open_terminal(project_id: String) -> Result<(), String> {
 // --- Windows terminals ---
 
 fn try_windows_terminal(project_path: &str, env_vars: &std::collections::HashMap<String, String>) -> bool {
-    // Windows Terminal (wt.exe)
-    if which::which("wt").is_ok() {
-        let mut cmd = Command::new("wt");
-        cmd.arg("-d").arg(project_path);
-        for (k, v) in env_vars {
-            cmd.env(k, v);
-        }
-        if cmd.spawn().is_ok() {
-            return true;
-        }
+    if path_has_control_chars(project_path) || which::which("wt").is_err() {
+        return false;
     }
-    false
+    let mut cmd = Command::new("wt");
+    cmd.arg("-d").arg(project_path);
+    for (k, v) in env_vars {
+        cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd.spawn().is_ok()
 }
 
 fn try_powershell(project_path: &str, env_vars: &std::collections::HashMap<String, String>) -> bool {
-    // PowerShell
+    if path_has_control_chars(project_path) {
+        return false;
+    }
     let ps = if which::which("pwsh").is_ok() {
         "pwsh"
     } else if which::which("powershell").is_ok() {
@@ -87,23 +104,49 @@ fn try_powershell(project_path: &str, env_vars: &std::collections::HashMap<Strin
         return false;
     };
 
-    let safe_path = project_path.replace('\'', "''");
+    // Usamos `start /D <path>` para que la nueva ventana de PowerShell
+    // arranque en el directorio correcto sin pasar el path dentro de un
+    // comando -Command (evita cualquier riesgo de inyeccion via el path).
     let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg("start").arg(ps).arg("-NoExit").arg("-Command")
-        .arg(format!("Set-Location '{}'", safe_path));
+    cmd.arg("/c")
+        .arg("start")
+        .arg("")
+        .arg("/D")
+        .arg(project_path)
+        .arg(ps)
+        .arg("-NoExit");
     for (k, v) in env_vars {
         cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
     cmd.spawn().is_ok()
 }
 
 fn try_cmd(project_path: &str, env_vars: &std::collections::HashMap<String, String>) -> bool {
-    let safe_path = project_path.replace('"', "");
+    if path_has_control_chars(project_path) {
+        return false;
+    }
+    // `start /D <path> cmd /K` abre una ventana nueva de cmd en el dir
+    // sin pasar el path por una cadena concatenada.
     let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg("start").arg("cmd").arg("/k")
-        .arg(format!("cd /d \"{}\"", safe_path));
+    cmd.arg("/c")
+        .arg("start")
+        .arg("")
+        .arg("/D")
+        .arg(project_path)
+        .arg("cmd")
+        .arg("/K");
     for (k, v) in env_vars {
         cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
     cmd.spawn().is_ok()
 }
@@ -208,12 +251,12 @@ fn try_linux_terminals(project_path: &str, env_vars: &std::collections::HashMap<
         }
     }
 
-    // xterm fallback
+    // xterm fallback: xterm no tiene --working-directory, pero hereda el
+    // cwd del proceso padre — seteamos cwd via Command::current_dir para
+    // evitar concatenar el path en un string de shell.
     if which::which("xterm").is_ok() {
-        let safe_path = project_path.replace('\'', "'\\''");
-        let shell_cmd = format!("cd '{}' && exec $SHELL", safe_path);
         let mut cmd = Command::new("xterm");
-        cmd.arg("-e").arg("sh").arg("-c").arg(&shell_cmd);
+        cmd.current_dir(project_path);
         for (k, v) in env_vars {
             cmd.env(k, v);
         }

--- a/src-tauri/src/core/analysis/detection.rs
+++ b/src-tauri/src/core/analysis/detection.rs
@@ -83,10 +83,10 @@ pub fn detect_stack(project_path: &str) -> Result<DetectedStack, NexenvError> {
                     if let Some(obj) = dep_obj.as_object() {
                         for key in obj.keys() {
                             match key.as_str() {
-                                "react" | "react-dom" => {
-                                    if !detected_tags.contains(&"react".to_string()) {
-                                        detected_tags.push("react".to_string());
-                                    }
+                                "react" | "react-dom"
+                                    if !detected_tags.contains(&"react".to_string()) =>
+                                {
+                                    detected_tags.push("react".to_string());
                                 }
                                 "next" => detected_tags.push("nextjs".to_string()),
                                 "vue" => detected_tags.push("vue".to_string()),

--- a/src-tauri/src/core/project/portable.rs
+++ b/src-tauri/src/core/project/portable.rs
@@ -1,3 +1,5 @@
+use std::path::{Component, Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
 
 use crate::core::error::NexenvError;
@@ -59,8 +61,57 @@ pub fn export_project(project_id: &str) -> Result<String, NexenvError> {
     Ok(json)
 }
 
+/// Valida el target_path de un import contra path traversal, control chars
+/// y paths relativos. Devuelve el path normalizado.
+///
+/// No canonicaliza (el path puede no existir todavia), pero rechaza:
+/// - Strings vacios.
+/// - Paths relativos (debe ser absoluto).
+/// - Control chars (\n, \r, \0, etc.) que pueden romper parsers downstream.
+/// - Cualquier componente `..` (ParentDir) — corta traversal explicito.
+pub fn validate_target_path(target: &str) -> Result<PathBuf, NexenvError> {
+    if target.trim().is_empty() {
+        return Err(NexenvError::InvalidPath(
+            "El path de destino no puede estar vacio".to_string(),
+        ));
+    }
+
+    if target.chars().any(|c| c.is_control()) {
+        return Err(NexenvError::InvalidPath(
+            "El path contiene caracteres de control".to_string(),
+        ));
+    }
+
+    let path = PathBuf::from(target);
+
+    if !path.is_absolute() {
+        return Err(NexenvError::InvalidPath(format!(
+            "El path debe ser absoluto: {}",
+            target
+        )));
+    }
+
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(NexenvError::InvalidPath(format!(
+            "El path contiene traversal ('..'): {}",
+            target
+        )));
+    }
+
+    // Si el path existe, canonicalizar para resolver symlinks y comparar
+    // contra cualquier constraint futuro. Si no existe (caso normal en
+    // un import a carpeta nueva), devolvemos el path tal cual.
+    match Path::new(&path).canonicalize() {
+        Ok(resolved) => Ok(resolved),
+        Err(_) => Ok(path),
+    }
+}
+
 /// Importa un proyecto desde JSON portable (.nexenv)
 pub fn import_project(json: &str, target_path: &str) -> Result<Project, NexenvError> {
+    let validated = validate_target_path(target_path)?;
+    let target_path = validated.to_string_lossy().to_string();
+
     let export: NexenvExport = serde_json::from_str(json)?;
 
     let now = chrono::Utc::now().to_rfc3339();
@@ -102,7 +153,7 @@ pub fn import_project(json: &str, target_path: &str) -> Result<Project, NexenvEr
 
     // Restaurar manifest si viene en el export
     if let Some(m) = export.manifest {
-        let _ = manifest::save_manifest(target_path, &m);
+        let _ = manifest::save_manifest(&target_path, &m);
     }
 
     Ok(project)
@@ -115,11 +166,18 @@ mod tests {
     use crate::core::store;
     use serial_test::serial;
 
+    fn temp_path(suffix: &str) -> String {
+        std::env::temp_dir()
+            .join(format!("nexenv-portable-test-{}", suffix))
+            .to_string_lossy()
+            .to_string()
+    }
+
     fn make_test_project(suffix: &str) -> Project {
         Project {
             id: format!("test-portable-{}", suffix),
             name: format!("Portable Test {}", suffix),
-            path: format!("/tmp/nexenv-portable-test-{}", suffix),
+            path: temp_path(suffix),
             description: Some("portable test".to_string()),
             runtimes: vec![RuntimeConfig {
                 runtime: "node".to_string(),
@@ -173,19 +231,19 @@ mod tests {
         let json = export_project(&proj.id).expect("export should succeed");
 
         // Import at a different path
-        let import_path = "/tmp/nexenv-portable-import-roundtrip";
-        cleanup_by_path(import_path);
-        let imported = import_project(&json, import_path).expect("import should succeed");
+        let import_path = temp_path("import-roundtrip");
+        cleanup_by_path(&import_path);
+        let imported = import_project(&json, &import_path).expect("import should succeed");
 
         assert_eq!(imported.name, proj.name);
-        assert_eq!(imported.path, import_path);
+        assert!(imported.path.ends_with("nexenv-portable-test-import-roundtrip"));
         assert_eq!(imported.tags, proj.tags);
         assert_ne!(imported.id, proj.id, "imported project should get a new id");
 
         // Cleanup
         cleanup_project(&proj_id);
         cleanup_project(&imported.id);
-        cleanup_by_path(import_path);
+        cleanup_by_path(&import_path);
     }
 
     #[test]
@@ -199,8 +257,80 @@ mod tests {
     #[test]
     fn test_import_invalid_json() {
         crate::core::store::init_test_store();
-        let result = import_project("this is not json", "/tmp/nexenv-invalid");
+        let path = temp_path("invalid");
+        let result = import_project("this is not json", &path);
         assert!(result.is_err(), "importing invalid JSON should error");
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_empty() {
+        assert!(matches!(
+            validate_target_path(""),
+            Err(NexenvError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            validate_target_path("   "),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_control_chars() {
+        assert!(matches!(
+            validate_target_path("/tmp/evil\n/etc/passwd"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            validate_target_path("/tmp/evil\0null"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_relative() {
+        assert!(matches!(
+            validate_target_path("relative/path"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            validate_target_path("./foo"),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_rejects_traversal() {
+        #[cfg(unix)]
+        let evil = "/tmp/../etc/passwd";
+        #[cfg(windows)]
+        let evil = r"C:\tmp\..\Windows\System32";
+        assert!(matches!(
+            validate_target_path(evil),
+            Err(NexenvError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_target_path_accepts_valid() {
+        let valid = temp_path("valid-path-check");
+        assert!(validate_target_path(&valid).is_ok());
+    }
+
+    #[test]
+    fn test_import_rejects_invalid_path() {
+        crate::core::store::init_test_store();
+        let bogus_json = serde_json::json!({
+            "version": "1",
+            "exportedAt": "2026-01-01T00:00:00Z",
+            "project": {
+                "name": "x", "runtimes": [], "tags": [], "envKeys": []
+            }
+        })
+        .to_string();
+        // relative path
+        assert!(import_project(&bogus_json, "relative/path").is_err());
+        // control char
+        assert!(import_project(&bogus_json, "/tmp/evil\nname").is_err());
     }
 
     #[test]

--- a/src-tauri/src/core/runtime/scripts.rs
+++ b/src-tauri/src/core/runtime/scripts.rs
@@ -77,11 +77,17 @@ const ALLOWED_EXECUTABLES: &[&str] = &[
     // Version managers
     "nvm", "fnm", "pyenv", "rustup",
     // Generic dev
-    "echo", "cat", "ls", "pwd", "env", "printenv", "which", "true",
+    "echo", "cat", "ls", "pwd", "which", "true",
 ];
 
 /// Shell metacaracteres que permiten encadenar comandos arbitrarios.
 const DANGEROUS_CHARS: &[char] = &['|', '`', '$', '(', ')', ';', '&', '<', '>'];
+
+/// Chars Unicode de formato bidireccional que permiten ofuscar comandos visualmente.
+/// U+202A..U+202E (embeddings/overrides) y U+2066..U+2069 (isolates).
+fn is_bidi_format_char(c: char) -> bool {
+    matches!(c as u32, 0x202A..=0x202E | 0x2066..=0x2069)
+}
 
 fn validate_script_command(command: &str) -> Result<(), NexenvError> {
     if command.len() > 500 {
@@ -94,6 +100,16 @@ fn validate_script_command(command: &str) -> Result<(), NexenvError> {
         return Err(NexenvError::InvalidConfig(
             "Comando vacio".to_string(),
         ));
+    }
+
+    // Rechazar control chars (newline, tab, null, BEL, ESC, etc.) y bidi overrides.
+    for ch in command.chars() {
+        if ch.is_control() || is_bidi_format_char(ch) {
+            return Err(NexenvError::InvalidConfig(format!(
+                "Comando contiene caracter de control no permitido: {:?}",
+                ch
+            )));
+        }
     }
 
     // Rechazar metacaracteres de shell que permiten inyección
@@ -235,5 +251,29 @@ mod tests {
     fn test_validate_script_command_empty() {
         assert!(validate_script_command("").is_err());
         assert!(validate_script_command("  ").is_err());
+    }
+
+    #[test]
+    fn test_validate_script_command_rejects_control_chars() {
+        assert!(validate_script_command("npm run dev\nrm -rf /").is_err());
+        assert!(validate_script_command("npm run dev\r\nevil").is_err());
+        assert!(validate_script_command("npm run\tdev").is_err());
+        assert!(validate_script_command("npm run dev\0evil").is_err());
+        assert!(validate_script_command("npm run dev\x07").is_err());
+        assert!(validate_script_command("npm run dev\x1b[31m").is_err());
+    }
+
+    #[test]
+    fn test_validate_script_command_rejects_bidi_override() {
+        assert!(validate_script_command("npm run \u{202E}dev").is_err());
+        assert!(validate_script_command("npm run \u{202D}dev").is_err());
+        assert!(validate_script_command("npm run \u{2066}dev").is_err());
+    }
+
+    #[test]
+    fn test_validate_script_command_blocks_env_printenv() {
+        assert!(validate_script_command("env").is_err());
+        assert!(validate_script_command("env FOO=bar").is_err());
+        assert!(validate_script_command("printenv PATH").is_err());
     }
 }

--- a/src-tauri/src/core/store/sqlite_store.rs
+++ b/src-tauri/src/core/store/sqlite_store.rs
@@ -470,7 +470,7 @@ mod tests {
         let proj = make_project("crud");
 
         // Save
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         // List
         let projects = store.list_projects().unwrap();
@@ -483,7 +483,7 @@ mod tests {
         // Update (save all)
         let mut updated = proj.clone();
         updated.name = "Updated".to_string();
-        store.save_projects(&[updated.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&updated)).unwrap();
         let projects = store.list_projects().unwrap();
         assert_eq!(projects[0].name, "Updated");
 
@@ -515,7 +515,7 @@ mod tests {
     fn test_notes_crud() {
         let store = make_store();
         let proj = make_project("notes");
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         // Add
         let note = store.add_note(&proj.id, "Test note").unwrap();
@@ -536,7 +536,7 @@ mod tests {
     fn test_env_vars_crud() {
         let store = make_store();
         let proj = make_project("env");
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         let mut vars = HashMap::new();
         vars.insert("API_KEY".to_string(), "secret".to_string());
@@ -556,7 +556,7 @@ mod tests {
     fn test_cascade_delete() {
         let store = make_store();
         let proj = make_project("cascade");
-        store.save_projects(&[proj.clone()]).unwrap();
+        store.save_projects(std::slice::from_ref(&proj)).unwrap();
 
         // Add env vars and notes
         let mut vars = HashMap::new();

--- a/src-tauri/src/core/workspace/mod.rs
+++ b/src-tauri/src/core/workspace/mod.rs
@@ -1,2 +1,3 @@
 pub mod scaffold;
+mod scaffold_constants;
 pub mod vscode;

--- a/src-tauri/src/core/workspace/scaffold.rs
+++ b/src-tauri/src/core/workspace/scaffold.rs
@@ -600,7 +600,7 @@ mod tests {
             ..basic_config()
         };
         let all_techs = catalog::load_all_technologies();
-        let compose = generate_docker_compose(&config, &all_techs);
+        let compose = generate_docker_compose(&config, all_techs);
         assert!(compose.contains("postgresql"));
         assert!(compose.contains("services:"));
     }
@@ -609,7 +609,7 @@ mod tests {
     fn test_generate_docker_compose_no_db() {
         let config = basic_config();
         let all_techs = catalog::load_all_technologies();
-        let compose = generate_docker_compose(&config, &all_techs);
+        let compose = generate_docker_compose(&config, all_techs);
         assert!(compose.is_empty());
     }
 

--- a/src-tauri/src/core/workspace/scaffold.rs
+++ b/src-tauri/src/core/workspace/scaffold.rs
@@ -9,6 +9,10 @@ use crate::core::models::project::{Project, ProjectStatus, RuntimeConfig};
 use crate::core::rules;
 use crate::core::store;
 use crate::core::utils::fs::ensure_dir;
+use crate::core::workspace::scaffold_constants::{
+    ACTIONS_CHECKOUT_SHA, ACTIONS_CHECKOUT_VERSION, ACTIONS_SETUP_NODE_SHA,
+    ACTIONS_SETUP_NODE_VERSION, ACTIONS_SETUP_PYTHON_SHA, ACTIONS_SETUP_PYTHON_VERSION,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -383,8 +387,8 @@ fn generate_ci_workflow(config: &ScaffoldConfig) -> String {
             "  build:".to_string(),
             "    runs-on: ubuntu-latest".to_string(),
             "    steps:".to_string(),
-            "      - uses: actions/checkout@v4".to_string(),
-            "      - uses: actions/setup-node@v4".to_string(),
+            format!("      - uses: actions/checkout@{ACTIONS_CHECKOUT_SHA} # {ACTIONS_CHECKOUT_VERSION}"),
+            format!("      - uses: actions/setup-node@{ACTIONS_SETUP_NODE_SHA} # {ACTIONS_SETUP_NODE_VERSION}"),
             "        with:".to_string(),
             "          node-version: 20".to_string(),
             "          cache: npm".to_string(),
@@ -403,8 +407,8 @@ fn generate_ci_workflow(config: &ScaffoldConfig) -> String {
             "  test:".to_string(),
             "    runs-on: ubuntu-latest".to_string(),
             "    steps:".to_string(),
-            "      - uses: actions/checkout@v4".to_string(),
-            "      - uses: actions/setup-python@v5".to_string(),
+            format!("      - uses: actions/checkout@{ACTIONS_CHECKOUT_SHA} # {ACTIONS_CHECKOUT_VERSION}"),
+            format!("      - uses: actions/setup-python@{ACTIONS_SETUP_PYTHON_SHA} # {ACTIONS_SETUP_PYTHON_VERSION}"),
             "        with:".to_string(),
             "          python-version: '3.12'".to_string(),
             "      - run: pip install -r requirements.txt".to_string(),

--- a/src-tauri/src/core/workspace/scaffold_constants.rs
+++ b/src-tauri/src/core/workspace/scaffold_constants.rs
@@ -1,0 +1,13 @@
+//! SHAs pineados para workflows generados por scaffold.
+//!
+//! Se mantienen sincronizados con los workflows del propio repo
+//! delixon-nexenv (.github/workflows/*.yml) via dependabot.
+
+pub const ACTIONS_CHECKOUT_SHA: &str = "34e114876b0b11c390a56381ad16ebd13914f8d5";
+pub const ACTIONS_CHECKOUT_VERSION: &str = "v4.3.1";
+
+pub const ACTIONS_SETUP_NODE_SHA: &str = "49933ea5288caeca8642d1e84afbd3f7d6820020";
+pub const ACTIONS_SETUP_NODE_VERSION: &str = "v4.4.0";
+
+pub const ACTIONS_SETUP_PYTHON_SHA: &str = "a26af69be951a213d495a4c3e4e4022e16d87065";
+pub const ACTIONS_SETUP_PYTHON_VERSION: &str = "v5.6.0";

--- a/src-tauri/src/enterprise/license.rs
+++ b/src-tauri/src/enterprise/license.rs
@@ -1,7 +1,37 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Deserialize;
 
 const VALIDATION_URL: &str = "https://app.delixon.dev/api/store/license/validate/";
+
+// Solo alfanumerico, guion y underscore, 8-64 chars.
+static KEY_FORMAT: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[A-Za-z0-9_-]{8,64}$").expect("regex invariante"));
+
+#[derive(Debug, thiserror::Error)]
+pub enum LicenseError {
+    #[error("Formato de clave invalido")]
+    InvalidFormat,
+    #[error("Error de red: {0}")]
+    Network(#[from] reqwest::Error),
+    #[error("Servidor rechazo la licencia (status {0})")]
+    Server(reqwest::StatusCode),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct LicenseInfo {
+    #[serde(default)]
+    pub valid: bool,
+    #[serde(default)]
+    pub plan: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+}
 
 fn license_key_path() -> PathBuf {
     let home = dirs::home_dir().expect("No se encontro el directorio home");
@@ -13,14 +43,34 @@ fn read_license_key() -> Option<String> {
     fs::read_to_string(path).ok().map(|s| s.trim().to_string())
 }
 
-pub async fn validate_license(key: &str) -> bool {
-    let url = format!("{}?key={}", VALIDATION_URL, key);
-    let client = reqwest::Client::new();
-
-    match client.get(&url).send().await {
-        Ok(response) => response.status().is_success(),
-        Err(_) => false,
+pub fn validate_key_format(key: &str) -> Result<(), LicenseError> {
+    if KEY_FORMAT.is_match(key) {
+        Ok(())
+    } else {
+        Err(LicenseError::InvalidFormat)
     }
+}
+
+pub async fn validate_license(key: &str) -> Result<LicenseInfo, LicenseError> {
+    validate_key_format(key)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .user_agent(concat!("Nexenv/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let response = client
+        .post(VALIDATION_URL)
+        .json(&serde_json::json!({ "key": key }))
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(LicenseError::Server(response.status()));
+    }
+
+    let info: LicenseInfo = response.json().await?;
+    Ok(info)
 }
 
 pub fn is_enterprise() -> bool {
@@ -30,18 +80,19 @@ pub fn is_enterprise() -> bool {
     };
 
     let rt = tokio::runtime::Handle::try_current();
-    match rt {
-        Ok(handle) => {
-            tokio::task::block_in_place(|| handle.block_on(validate_license(&key)))
-        }
+    let result = match rt {
+        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(validate_license(&key))),
         Err(_) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(validate_license(&key))
         }
-    }
+    };
+
+    matches!(result, Ok(info) if info.valid)
 }
 
 pub fn activate_license(key: &str) -> Result<(), String> {
+    validate_key_format(key).map_err(|e| e.to_string())?;
     let path = license_key_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Error creando directorio: {}", e))?;
@@ -56,4 +107,72 @@ pub fn deactivate_license() -> Result<(), String> {
         fs::remove_file(&path).map_err(|e| format!("Error eliminando licencia: {}", e))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_format_rejects_empty() {
+        assert!(matches!(
+            validate_key_format(""),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_too_short() {
+        assert!(matches!(
+            validate_key_format("ABC123"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_too_long() {
+        let long = "a".repeat(65);
+        assert!(matches!(
+            validate_key_format(&long),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_sql_injection() {
+        assert!(matches!(
+            validate_key_format("FAKE' OR '1'='1"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_query_string_injection() {
+        assert!(matches!(
+            validate_key_format("FAKE&admin=true"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_rejects_control_chars() {
+        assert!(matches!(
+            validate_key_format("ABC\nDEF12345"),
+            Err(LicenseError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn key_format_accepts_valid() {
+        assert!(validate_key_format("abc-DEF-1234567").is_ok());
+        assert!(validate_key_format("LICENSE_KEY_2026").is_ok());
+        assert!(validate_key_format("12345678").is_ok());
+        assert!(validate_key_format(&"A".repeat(64)).is_ok());
+    }
+
+    #[test]
+    fn activate_license_rejects_invalid_format() {
+        assert!(activate_license("bad key!").is_err());
+        assert!(activate_license("").is_err());
+    }
 }

--- a/src-tauri/src/enterprise/license.rs
+++ b/src-tauri/src/enterprise/license.rs
@@ -1,10 +1,15 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::RwLock;
 use std::time::Duration;
 
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
+
+// Cache del resultado de is_enterprise(). None = sin consultar aun,
+// Some(v) = ultimo resultado conocido. Se invalida en activate/deactivate.
+static ENTERPRISE_STATUS: RwLock<Option<bool>> = RwLock::new(None);
 
 const VALIDATION_URL: &str = "https://app.delixon.dev/api/store/license/validate/";
 
@@ -73,22 +78,36 @@ pub async fn validate_license(key: &str) -> Result<LicenseInfo, LicenseError> {
     Ok(info)
 }
 
-pub fn is_enterprise() -> bool {
+pub fn invalidate_enterprise_cache() {
+    if let Ok(mut guard) = ENTERPRISE_STATUS.write() {
+        *guard = None;
+    }
+}
+
+fn set_enterprise_cache(value: bool) {
+    if let Ok(mut guard) = ENTERPRISE_STATUS.write() {
+        *guard = Some(value);
+    }
+}
+
+pub async fn is_enterprise() -> bool {
+    // Cache hit: una sola pasada por la red; subsiguientes llamadas la
+    // reutilizan hasta que activate/deactivate invalide.
+    if let Some(cached) = ENTERPRISE_STATUS.read().ok().and_then(|g| *g) {
+        return cached;
+    }
+
     let key = match read_license_key() {
         Some(k) if !k.is_empty() => k,
-        _ => return false,
-    };
-
-    let rt = tokio::runtime::Handle::try_current();
-    let result = match rt {
-        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(validate_license(&key))),
-        Err(_) => {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(validate_license(&key))
+        _ => {
+            set_enterprise_cache(false);
+            return false;
         }
     };
 
-    matches!(result, Ok(info) if info.valid)
+    let valid = matches!(validate_license(&key).await, Ok(info) if info.valid);
+    set_enterprise_cache(valid);
+    valid
 }
 
 pub fn activate_license(key: &str) -> Result<(), String> {
@@ -98,6 +117,7 @@ pub fn activate_license(key: &str) -> Result<(), String> {
         fs::create_dir_all(parent).map_err(|e| format!("Error creando directorio: {}", e))?;
     }
     fs::write(&path, key).map_err(|e| format!("Error guardando licencia: {}", e))?;
+    invalidate_enterprise_cache();
     Ok(())
 }
 
@@ -106,6 +126,7 @@ pub fn deactivate_license() -> Result<(), String> {
     if path.exists() {
         fs::remove_file(&path).map_err(|e| format!("Error eliminando licencia: {}", e))?;
     }
+    invalidate_enterprise_cache();
     Ok(())
 }
 
@@ -174,5 +195,13 @@ mod tests {
     fn activate_license_rejects_invalid_format() {
         assert!(activate_license("bad key!").is_err());
         assert!(activate_license("").is_err());
+    }
+
+    #[test]
+    fn invalidate_cache_resets_status() {
+        set_enterprise_cache(true);
+        assert_eq!(*ENTERPRISE_STATUS.read().unwrap(), Some(true));
+        invalidate_enterprise_cache();
+        assert_eq!(*ENTERPRISE_STATUS.read().unwrap(), None);
     }
 }

--- a/src-tauri/src/enterprise/mod.rs
+++ b/src-tauri/src/enterprise/mod.rs
@@ -5,6 +5,6 @@ pub mod license;
 pub use license::is_enterprise;
 
 #[cfg(not(feature = "enterprise"))]
-pub fn is_enterprise() -> bool {
+pub async fn is_enterprise() -> bool {
     false
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,11 +16,16 @@ pub fn run() {
     // Inicializar store global: SQLite con fallback a JSON
     core::store::init(init_store());
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_dialog::init());
+
+    #[cfg(feature = "auto-updater")]
+    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+
+    builder
         .invoke_handler(tauri::generate_handler![
             // Projects
             projects::list_projects,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,17 @@
       "icons/128x128@2x.png",
       "icons/icon.ico",
       "icons/icon.png"
-    ]
+    ],
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "active": false,
+      "dialog": false,
+      "endpoints": [
+        "https://app.delixon.dev/api/nexenv/update/{{target}}/{{arch}}/{{current_version}}"
+      ],
+      "pubkey": "REEMPLAZAR_CON_LA_PUBLIC_KEY_GENERADA_POR_TAURI_SIGNER"
+    }
   }
 }


### PR DESCRIPTION
## Resumen

Bloque 7 completo: auditoria 2026-04-16 aterrizada en 7 PRs atomicos. Incluye ademas un hotfix del CI que se rompio al promover lints de clippy 1.95 a error.

## PRs consolidados

| PR | Titulo | Issues |
|----|--------|--------|
| #81 | reject control/bidi chars + remove env/printenv | H-4, L-3 |
| #82 | hotfix clippy lints rust 1.94/1.95 | — |
| #83 | pin github actions a SHA + scaffold constants | H-3, H-7 |
| #84 | license POST + key format validation | H-5, H-6 |
| #85 | validate import paths + sanitize shell launchers | M-1, M-10 |
| #86 | restringir scope fs + cachear is_enterprise | L-4, L-5 |
| #87 | cargo-audit + cargo-deny en CI | M-2, L-11 |
| #88 | scaffold del auto-updater firmado | L-12 |

## Areas tocadas

### Inyeccion / validacion
- Scripts de manifest rechazan control chars y bidi overrides; se quitan \`env\`/\`printenv\` del allowlist.
- License key validada con regex antes de enviar al servidor.
- Paths de \`import_project\` validados: absoluto, sin \`..\`, sin control chars.
- Shell launchers en Windows dejaron de concatenar paths en strings de shell; usan \`start /D\` y args explicitos.

### Red y datos
- Validacion de licencia pasa de GET con query string a POST con JSON body (deja de quedar en logs de proxy/CDN).
- Timeout + user-agent identificable en el cliente reqwest.
- \`is_enterprise\` async y cacheado; se elimina \`block_in_place\`.

### Supply chain
- Todas las GitHub Actions pineadas a SHA (ci, build, release, npm-publish).
- Scaffold genera CI con las mismas SHAs via \`scaffold_constants.rs\`.
- \`.github/dependabot.yml\`: update semanal de github-actions, cargo y npm.
- Nuevo workflow \`security-audit.yml\`: cargo-audit + cargo-deny en PRs y cron semanal.
- \`src-tauri/deny.toml\`: allowlist de licencias, \`yanked = deny\`, solo crates.io.

### Tauri / capabilities
- Permisos \`fs:*\` retirados del capability default (el frontend no usa plugin-fs).
- Scaffold del auto-updater (feature flag \`auto-updater\`, off por default, requiere keypair + secret + endpoint para activar).

## Verificacion
- \`cargo clippy --all-targets -- -D warnings\` → pasa.
- \`cargo clippy --features enterprise --all-targets -- -D warnings\` → pasa.
- \`cargo clippy --features auto-updater --all-targets -- -D warnings\` → pasa.
- \`cargo test --lib\` → **148/148 OK** (default).
- \`cargo test --features enterprise --lib\` → **157/157 OK** (default + 9 license).

## Pendiente (fuera de este bloque)
- Generar keypair del updater y subir secret a GH Actions (L-12 activation).
- Endpoint \`/api/nexenv/update/...\` en delixon-platform.
- Coordinar con @platform que \`LicenseValidateView\` acepte POST con \`{"key": "..."}\` (ya documentado en #84).