### PR TITLE
fix(npm): wrapper + plan de distribucion v1.0.0

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -34,11 +34,5 @@
   ],
   "engines": {
     "node": ">=22"
-  },
-  "optionalDependencies": {
-    "@delixon/nexenv-win32-x64": "0.0.1",
-    "@delixon/nexenv-linux-x64": "0.0.1",
-    "@delixon/nexenv-darwin-arm64": "0.0.1",
-    "@delixon/nexenv-darwin-x64": "0.0.1"
   }
 }

--- a/npm/cli/scripts/postinstall.js
+++ b/npm/cli/scripts/postinstall.js
@@ -1,36 +1,81 @@
 /* eslint-env node */
 const { platform, arch } = process;
-const { existsSync, copyFileSync, chmodSync } = require("fs");
+const https = require("https");
+const { createWriteStream, chmodSync, existsSync, mkdirSync, unlinkSync } = require("fs");
 const { join } = require("path");
 
-const PLATFORM_MAP = {
-  "win32-x64": "@delixon/nexenv-win32-x64",
-  "linux-x64": "@delixon/nexenv-linux-x64",
-  "darwin-arm64": "@delixon/nexenv-darwin-arm64",
-  "darwin-x64": "@delixon/nexenv-darwin-x64",
+const ASSET_MAP = {
+  "win32-x64": "nexenv-cli-win32-x64.exe",
+  "linux-x64": "nexenv-cli-linux-x64",
+  "darwin-arm64": "nexenv-cli-darwin-arm64",
+  "darwin-x64": "nexenv-cli-darwin-x64",
 };
 
 const key = `${platform}-${arch}`;
-const pkg = PLATFORM_MAP[key];
+const asset = ASSET_MAP[key];
 
-if (!pkg) {
+if (!asset) {
   console.error(`Nexenv: plataforma no soportada (${key})`);
   console.error("Plataformas soportadas: win32-x64, linux-x64, darwin-arm64, darwin-x64");
   process.exit(1);
 }
 
-const binaryName = platform === "win32" ? "nexenv.exe" : "nexenv";
-
-try {
-  const binaryPath = require.resolve(`${pkg}/${binaryName}`);
-  const destPath = join(__dirname, "..", "bin", binaryName);
-
-  copyFileSync(binaryPath, destPath);
-
-  if (platform !== "win32") {
-    chmodSync(destPath, 0o755);
-  }
-} catch {
-  // El paquete opcional no se instalo (plataforma diferente)
-  // Esto es normal en CI o cross-platform
+if (process.env.NEXENV_SKIP_POSTINSTALL === "1") {
+  process.exit(0);
 }
+
+const pkg = require("../package.json");
+const version = pkg.version;
+const url = `https://github.com/delixon-labs/delixon-nexenv/releases/download/v${version}/${asset}`;
+const binaryName = platform === "win32" ? "nexenv.exe" : "nexenv";
+const binDir = join(__dirname, "..", "bin");
+const destPath = join(binDir, binaryName);
+
+if (!existsSync(binDir)) {
+  mkdirSync(binDir, { recursive: true });
+}
+
+function download(u, dest, maxRedirects) {
+  return new Promise((resolve, reject) => {
+    function attempt(current, remaining) {
+      if (remaining < 0) {
+        reject(new Error("demasiados redirects"));
+        return;
+      }
+      https
+        .get(current, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            attempt(res.headers.location, remaining - 1);
+            return;
+          }
+          if (res.statusCode !== 200) {
+            reject(new Error(`HTTP ${res.statusCode} al descargar ${current}`));
+            return;
+          }
+          const file = createWriteStream(dest);
+          res.pipe(file);
+          file.on("finish", () => file.close(() => resolve()));
+          file.on("error", (err) => {
+            try { unlinkSync(dest); } catch { /* ignore */ }
+            reject(err);
+          });
+        })
+        .on("error", reject);
+    }
+    attempt(u, maxRedirects);
+  });
+}
+
+console.log(`Nexenv: descargando binario v${version} para ${key}...`);
+download(url, destPath, 5)
+  .then(() => {
+    if (platform !== "win32") chmodSync(destPath, 0o755);
+    console.log(`Nexenv: binario instalado en ${destPath}`);
+  })
+  .catch((err) => {
+    console.error(`Nexenv: error descargando el binario: ${err.message}`);
+    console.error(`URL intentada: ${url}`);
+    console.error("Descarga manual: https://github.com/delixon-labs/delixon-nexenv/releases");
+    console.error("Asigna NEXENV_SKIP_POSTINSTALL=1 si estas en un entorno sin red.");
+    process.exit(1);
+  });

--- a/src-tauri/src/commands/portable.rs
+++ b/src-tauri/src/commands/portable.rs
@@ -8,8 +8,32 @@ pub async fn export_project(project_id: String) -> Result<String, String> {
     portable::export_project(&project_id).map_err(|e| e.to_string())
 }
 
+/// Devuelve un resumen del import sin tocar disco ni store
+#[command]
+pub async fn preview_import(
+    json: String,
+    target_path: String,
+) -> Result<crate::core::project::portable::ImportPreview, crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
+    crate::core::project::portable::preview_import(&json, &target_path).map_err(|e| {
+        UiError::new("preview de import")
+            .detecto(format!("destino: '{}'", target_path))
+            .fallo(e.to_string())
+            .hacer("verifica que el JSON sea valido y que la ruta destino sea absoluta")
+    })
+}
+
 /// Importa un proyecto desde JSON portable
 #[command]
-pub async fn import_project(json: String, target_path: String) -> Result<Project, String> {
-    portable::import_project(&json, &target_path).map_err(|e| e.to_string())
+pub async fn import_project(
+    json: String,
+    target_path: String,
+) -> Result<Project, crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
+    portable::import_project(&json, &target_path).map_err(|e| {
+        UiError::new("importar proyecto desde archivo .nexenv")
+            .detecto(format!("destino: '{}'", target_path))
+            .fallo(e.to_string())
+            .hacer("verifica que el JSON sea valido, que la carpeta destino sea accesible y que no exista un proyecto con el mismo id")
+    })
 }

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -69,9 +69,12 @@ pub async fn create_project(input: CreateProjectInput) -> Result<Project, String
     Ok(project)
 }
 
-/// Abre un proyecto en el editor configurado (por defecto VSCode)
+/// Abre un proyecto en el editor configurado (por defecto VSCode).
+/// Activa los runtimes declarados en el manifest (nvm/fnm/pyenv/rustup) anteponiendo
+/// sus directorios bin al PATH del proceso hijo.
 #[command]
 pub async fn open_project(id: String) -> Result<(), String> {
+    let total = std::time::Instant::now();
     let mut projects = store::get().list_projects().map_err(|e| e.to_string())?;
 
     let project = projects
@@ -79,7 +82,6 @@ pub async fn open_project(id: String) -> Result<(), String> {
         .find(|p| p.id == id)
         .ok_or_else(|| format!("Proyecto no encontrado: {}", id))?;
 
-    // Verificar que la carpeta exista
     let project_path = project.path.clone();
     let path = std::path::Path::new(&project_path);
     if !path.exists() || !path.is_dir() {
@@ -89,18 +91,34 @@ pub async fn open_project(id: String) -> Result<(), String> {
         ));
     }
 
-    // Actualizar last_opened_at
+    let runtimes = project.runtimes.clone();
+
     project.last_opened_at = Some(chrono::Utc::now().to_rfc3339());
     project.status = ProjectStatus::Active;
     store::get().save_projects(&projects).map_err(|e| e.to_string())?;
 
-    // Abrir en editor configurado
     let editor = store::get()
         .load_config()
         .map(|c| c.default_editor)
         .unwrap_or_else(|_| "code".to_string());
 
-    crate::core::utils::editor::open_in_editor(&project_path, &editor)?;
+    let activation = crate::core::runtime::activate::activate(&runtimes);
+    let mut env = std::collections::HashMap::new();
+    if !activation.bin_paths.is_empty() {
+        let current = std::env::var("PATH").unwrap_or_default();
+        env.insert("PATH".to_string(), activation.prefix_path(&current));
+    }
+
+    crate::core::utils::editor::open_in_editor_with_env(&project_path, &editor, &env)?;
+
+    let total_ms = total.elapsed().as_millis();
+    println!(
+        "[nexenv] open_project id={} runtimes={} activation_ms={} total_ms={}",
+        id,
+        runtimes.len(),
+        activation.elapsed_ms,
+        total_ms
+    );
 
     Ok(())
 }

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -73,29 +73,45 @@ pub async fn create_project(input: CreateProjectInput) -> Result<Project, String
 /// Activa los runtimes declarados en el manifest (nvm/fnm/pyenv/rustup) anteponiendo
 /// sus directorios bin al PATH del proceso hijo.
 #[command]
-pub async fn open_project(id: String) -> Result<(), String> {
+pub async fn open_project(id: String) -> Result<(), crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
     let total = std::time::Instant::now();
-    let mut projects = store::get().list_projects().map_err(|e| e.to_string())?;
+    let mut projects = store::get().list_projects().map_err(|e| {
+        UiError::new("abrir proyecto")
+            .detecto("no se pudo leer el listado de proyectos")
+            .fallo(e.to_string())
+            .hacer("verifica los permisos del data dir de Nexenv y reinicia la app")
+    })?;
 
     let project = projects
         .iter_mut()
         .find(|p| p.id == id)
-        .ok_or_else(|| format!("Proyecto no encontrado: {}", id))?;
+        .ok_or_else(|| {
+            UiError::new("abrir proyecto")
+                .detecto(format!("no existe el proyecto con id '{}'", id))
+                .fallo("Project not found")
+                .hacer("vuelve al dashboard y selecciona un proyecto valido")
+        })?;
 
     let project_path = project.path.clone();
     let path = std::path::Path::new(&project_path);
     if !path.exists() || !path.is_dir() {
-        return Err(format!(
-            "La carpeta del proyecto no existe: {}",
-            project_path
-        ));
+        return Err(UiError::new("abrir proyecto")
+            .detecto(format!("la carpeta del proyecto no existe en disco: {}", project_path))
+            .fallo("path inexistente o no es directorio")
+            .hacer("revisa si moviste o eliminaste la carpeta; actualiza la ruta en el proyecto"));
     }
 
     let runtimes = project.runtimes.clone();
 
     project.last_opened_at = Some(chrono::Utc::now().to_rfc3339());
     project.status = ProjectStatus::Active;
-    store::get().save_projects(&projects).map_err(|e| e.to_string())?;
+    store::get().save_projects(&projects).map_err(|e| {
+        UiError::new("abrir proyecto")
+            .detecto("no se pudo guardar el estado del proyecto")
+            .fallo(e.to_string())
+            .hacer("verifica los permisos del data dir de Nexenv")
+    })?;
 
     let editor = store::get()
         .load_config()
@@ -109,7 +125,13 @@ pub async fn open_project(id: String) -> Result<(), String> {
         env.insert("PATH".to_string(), activation.prefix_path(&current));
     }
 
-    crate::core::utils::editor::open_in_editor_with_env(&project_path, &editor, &env)?;
+    crate::core::utils::editor::open_in_editor_with_env(&project_path, &editor, &env)
+        .map_err(|e| {
+            UiError::new("abrir proyecto en el editor")
+                .detecto(format!("editor configurado: '{}'", editor))
+                .fallo(e)
+                .hacer(format!("instala '{}' o cambia el editor por defecto en Settings", editor))
+        })?;
 
     let total_ms = total.elapsed().as_millis();
     println!(

--- a/src-tauri/src/commands/recipes.rs
+++ b/src-tauri/src/commands/recipes.rs
@@ -19,12 +19,31 @@ pub async fn preview_recipe(project_id: String, recipe_id: String) -> Result<Rec
 }
 
 #[command]
-pub async fn apply_recipe(project_id: String, recipe_id: String) -> Result<RecipeApplyResult, String> {
-    let projects = store::get().list_projects().map_err(|e| e.to_string())?;
+pub async fn apply_recipe(
+    project_id: String,
+    recipe_id: String,
+) -> Result<RecipeApplyResult, crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
+    let projects = store::get().list_projects().map_err(|e| {
+        UiError::new(format!("aplicar recipe '{}'", recipe_id))
+            .detecto("no se pudo leer el listado de proyectos")
+            .fallo(e.to_string())
+            .hacer("verifica los permisos del data dir de Nexenv")
+    })?;
     let project = projects
         .iter()
         .find(|p| p.id == project_id)
-        .ok_or_else(|| format!("Proyecto no encontrado: {}", project_id))?;
+        .ok_or_else(|| {
+            UiError::new(format!("aplicar recipe '{}'", recipe_id))
+                .detecto(format!("no existe el proyecto con id '{}'", project_id))
+                .fallo("Project not found")
+                .hacer("vuelve al dashboard y selecciona un proyecto valido")
+        })?;
 
-    recipes::apply_recipe(&project.path, &recipe_id).map_err(|e| e.to_string())
+    recipes::apply_recipe(&project.path, &recipe_id).map_err(|e| {
+        UiError::new(format!("aplicar recipe '{}'", recipe_id))
+            .detecto(format!("proyecto: '{}'", project.name))
+            .fallo(e.to_string())
+            .hacer("revisa los archivos generados por el preview; si conflictan, hazles backup antes de reintentar")
+    })
 }

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -12,9 +12,11 @@ fn path_has_control_chars(path: &str) -> bool {
     path.chars().any(|c| c.is_control())
 }
 
-/// Abre una terminal en la carpeta del proyecto con el entorno correcto cargado
+/// Abre una terminal en la carpeta del proyecto con el entorno correcto cargado.
+/// Inyecta los bin paths de los runtimes declarados (nvm/fnm/pyenv/rustup) en PATH.
 #[command]
 pub async fn open_terminal(project_id: String) -> Result<(), String> {
+    let total = std::time::Instant::now();
     let projects = store::get().list_projects().map_err(|e| e.to_string())?;
     let project = projects
         .iter()
@@ -33,17 +35,19 @@ pub async fn open_terminal(project_id: String) -> Result<(), String> {
         ));
     }
 
-    // Cargar env vars del proyecto
     let mut env_vars = store::get().load_env_vars(&project_id).unwrap_or_default();
 
-    // Terminal history isolation (bash, zsh, PowerShell)
     if let Ok(history_path) = storage::get_history_path(&project_id) {
         let _ = storage::init_data_dir();
         let hp = history_path.to_string_lossy().to_string();
-        // bash y zsh usan HISTFILE
         env_vars.insert("HISTFILE".to_string(), hp.clone());
-        // PowerShell usa PSReadLineHistorySavePath
         env_vars.insert("PSReadLineHistorySavePath".to_string(), hp);
+    }
+
+    let activation = crate::core::runtime::activate::activate(&project.runtimes);
+    if !activation.bin_paths.is_empty() {
+        let current = std::env::var("PATH").unwrap_or_default();
+        env_vars.insert("PATH".to_string(), activation.prefix_path(&current));
     }
 
     if cfg!(target_os = "windows") {
@@ -69,6 +73,14 @@ pub async fn open_terminal(project_id: String) -> Result<(), String> {
             return Err("No se encontro un emulador de terminal instalado. Soportados: x-terminal-emulator, gnome-terminal, xfce4-terminal, konsole, mate-terminal, tilix, alacritty, kitty, wezterm, foot, terminator, sakura, lxterminal, xterm".to_string());
         }
     }
+
+    println!(
+        "[nexenv] open_terminal id={} runtimes={} activation_ms={} total_ms={}",
+        project_id,
+        project.runtimes.len(),
+        activation.elapsed_ms,
+        total.elapsed().as_millis()
+    );
 
     Ok(())
 }

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -8,6 +8,12 @@ pub async fn create_from_template(
     template_id: String,
     path: String,
     name: String,
-) -> Result<Project, String> {
-    templates::create_from_template(&template_id, &path, &name).map_err(|e| e.to_string())
+) -> Result<Project, crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
+    templates::create_from_template(&template_id, &path, &name).map_err(|e| {
+        UiError::new(format!("crear proyecto '{}' desde template '{}'", name, template_id))
+            .detecto(format!("ruta destino: '{}'", path))
+            .fallo(e.to_string())
+            .hacer("verifica que el template existe, que la carpeta destino sea escribible y que no contenga archivos en conflicto")
+    })
 }

--- a/src-tauri/src/commands/versioning.rs
+++ b/src-tauri/src/commands/versioning.rs
@@ -1,4 +1,4 @@
-use crate::core::versioning::{self, Snapshot, SnapshotDiff};
+use crate::core::versioning::{self, RollbackPreview, Snapshot, SnapshotDiff};
 use crate::core::store;
 use tauri::command;
 
@@ -24,12 +24,60 @@ pub async fn diff_snapshots(project_id: String, v1: u32, v2: u32) -> Result<Snap
 }
 
 #[command]
-pub async fn rollback_snapshot(project_id: String, version: u32) -> Result<(), String> {
-    let projects = store::get().list_projects().map_err(|e| e.to_string())?;
+pub async fn preview_rollback(
+    project_id: String,
+    version: u32,
+) -> Result<RollbackPreview, crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
+    let projects = store::get().list_projects().map_err(|e| {
+        UiError::new(format!("preview rollback v{}", version))
+            .detecto("no se pudo leer el listado de proyectos")
+            .fallo(e.to_string())
+            .hacer("verifica los permisos del data dir de Nexenv")
+    })?;
     let project = projects
         .iter()
         .find(|p| p.id == project_id)
-        .ok_or_else(|| format!("Proyecto no encontrado: {}", project_id))?;
+        .ok_or_else(|| {
+            UiError::new(format!("preview rollback v{}", version))
+                .detecto(format!("no existe el proyecto con id '{}'", project_id))
+                .fallo("Project not found")
+                .hacer("vuelve al dashboard y selecciona un proyecto valido")
+        })?;
+    versioning::preview_rollback(&project_id, &project.path, version).map_err(|e| {
+        UiError::new(format!("preview rollback v{}", version))
+            .detecto(format!("proyecto: '{}'", project.name))
+            .fallo(e.to_string())
+            .hacer("verifica que el snapshot existe y que el manifest sea legible")
+    })
+}
 
-    versioning::rollback_snapshot(&project_id, &project.path, version).map_err(|e| e.to_string())
+#[command]
+pub async fn rollback_snapshot(
+    project_id: String,
+    version: u32,
+) -> Result<(), crate::core::errors::UiError> {
+    use crate::core::errors::UiError;
+    let projects = store::get().list_projects().map_err(|e| {
+        UiError::new(format!("rollback al snapshot v{}", version))
+            .detecto("no se pudo leer el listado de proyectos")
+            .fallo(e.to_string())
+            .hacer("verifica los permisos del data dir de Nexenv")
+    })?;
+    let project = projects
+        .iter()
+        .find(|p| p.id == project_id)
+        .ok_or_else(|| {
+            UiError::new(format!("rollback al snapshot v{}", version))
+                .detecto(format!("no existe el proyecto con id '{}'", project_id))
+                .fallo("Project not found")
+                .hacer("vuelve al dashboard y selecciona un proyecto valido")
+        })?;
+
+    versioning::rollback_snapshot(&project_id, &project.path, version).map_err(|e| {
+        UiError::new(format!("rollback al snapshot v{}", version))
+            .detecto(format!("proyecto: '{}' (v{})", project.name, version))
+            .fallo(e.to_string())
+            .hacer("verifica que el snapshot existe y que la carpeta del proyecto es escribible")
+    })
 }

--- a/src-tauri/src/core/errors.rs
+++ b/src-tauri/src/core/errors.rs
@@ -1,0 +1,91 @@
+use serde::Serialize;
+
+/// Error estructurado que viaja al frontend con 4 campos uniformes.
+/// Permite al usuario entender que intentaba Nexenv, que detecto, donde fallo y que hacer.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiError {
+    pub intento: String,
+    pub detecto: String,
+    pub fallo: String,
+    pub hacer: String,
+}
+
+impl UiError {
+    pub fn new(intento: impl Into<String>) -> Self {
+        Self {
+            intento: intento.into(),
+            detecto: String::new(),
+            fallo: String::new(),
+            hacer: String::new(),
+        }
+    }
+
+    pub fn detecto(mut self, v: impl Into<String>) -> Self {
+        self.detecto = v.into();
+        self
+    }
+
+    pub fn fallo(mut self, v: impl Into<String>) -> Self {
+        self.fallo = v.into();
+        self
+    }
+
+    pub fn hacer(mut self, v: impl Into<String>) -> Self {
+        self.hacer = v.into();
+        self
+    }
+}
+
+impl std::fmt::Display for UiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "intento={} detecto={} fallo={} hacer={}",
+            self.intento, self.detecto, self.fallo, self.hacer
+        )
+    }
+}
+
+impl std::error::Error for UiError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_fills_all_fields() {
+        let e = UiError::new("abrir proyecto")
+            .detecto("falta carpeta")
+            .fallo("ENOENT: no such file")
+            .hacer("verificar que la ruta existe");
+        assert_eq!(e.intento, "abrir proyecto");
+        assert_eq!(e.detecto, "falta carpeta");
+        assert_eq!(e.fallo, "ENOENT: no such file");
+        assert_eq!(e.hacer, "verificar que la ruta existe");
+    }
+
+    #[test]
+    fn serializes_with_camelcase_keys() {
+        let e = UiError::new("a").detecto("b").fallo("c").hacer("d");
+        let s = serde_json::to_string(&e).unwrap();
+        assert!(s.contains("\"intento\""));
+        assert!(s.contains("\"detecto\""));
+        assert!(s.contains("\"fallo\""));
+        assert!(s.contains("\"hacer\""));
+    }
+
+    #[test]
+    fn empty_fields_default_to_empty_string() {
+        let e = UiError::new("solo intento");
+        assert_eq!(e.detecto, "");
+        assert_eq!(e.fallo, "");
+        assert_eq!(e.hacer, "");
+    }
+
+    #[test]
+    fn implements_std_error() {
+        let e = UiError::new("x");
+        let _: &dyn std::error::Error = &e;
+    }
+}

--- a/src-tauri/src/core/history/versioning.rs
+++ b/src-tauri/src/core/history/versioning.rs
@@ -143,6 +143,80 @@ pub fn rollback_snapshot(project_id: &str, project_path: &str, version: u32) -> 
     Ok(())
 }
 
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RollbackPreview {
+    pub target_version: u32,
+    pub target_timestamp: String,
+    pub current_manifest_exists: bool,
+    pub added_techs: Vec<String>,
+    pub removed_techs: Vec<String>,
+    pub added_recipes: Vec<String>,
+    pub removed_recipes: Vec<String>,
+    pub profile_changed: Option<(String, String)>,
+    pub editor_changed: Option<(Option<String>, Option<String>)>,
+    pub name_changed: Option<(String, String)>,
+    pub runtime_changed: Option<(String, String)>,
+}
+
+/// Calcula el cambio que aplicaria un rollback al snapshot `version`,
+/// sin tocar el manifest. El frontend lo muestra al usuario para confirmar.
+pub fn preview_rollback(
+    project_id: &str,
+    project_path: &str,
+    version: u32,
+) -> Result<RollbackPreview, NexenvError> {
+    let snapshots = list_snapshots(project_id)?;
+    let target = snapshots.iter().find(|s| s.version == version).ok_or_else(|| {
+        NexenvError::InvalidConfig(format!("Snapshot v{} no encontrado", version))
+    })?;
+
+    let current = manifest::load_manifest(project_path).unwrap_or(None);
+
+    let (added_techs, removed_techs, added_recipes, removed_recipes,
+         profile_changed, editor_changed, name_changed, runtime_changed) = match &current {
+        Some(cur) => {
+            let added_techs: Vec<String> = target.manifest.technologies.iter()
+                .filter(|t| !cur.technologies.contains(t)).cloned().collect();
+            let removed_techs: Vec<String> = cur.technologies.iter()
+                .filter(|t| !target.manifest.technologies.contains(t)).cloned().collect();
+            let added_recipes: Vec<String> = target.manifest.recipes_applied.iter()
+                .filter(|r| !cur.recipes_applied.contains(r)).cloned().collect();
+            let removed_recipes: Vec<String> = cur.recipes_applied.iter()
+                .filter(|r| !target.manifest.recipes_applied.contains(r)).cloned().collect();
+            let profile = if cur.profile != target.manifest.profile {
+                Some((cur.profile.clone(), target.manifest.profile.clone()))
+            } else { None };
+            let editor = if cur.editor != target.manifest.editor {
+                Some((cur.editor.clone(), target.manifest.editor.clone()))
+            } else { None };
+            let name = if cur.name != target.manifest.name {
+                Some((cur.name.clone(), target.manifest.name.clone()))
+            } else { None };
+            let runtime = if cur.runtime != target.manifest.runtime {
+                Some((cur.runtime.clone(), target.manifest.runtime.clone()))
+            } else { None };
+            (added_techs, removed_techs, added_recipes, removed_recipes,
+             profile, editor, name, runtime)
+        }
+        None => (
+            target.manifest.technologies.clone(),
+            Vec::new(),
+            target.manifest.recipes_applied.clone(),
+            Vec::new(),
+            None, None, None, None,
+        ),
+    };
+
+    Ok(RollbackPreview {
+        target_version: target.version,
+        target_timestamp: target.timestamp.clone(),
+        current_manifest_exists: current.is_some(),
+        added_techs, removed_techs, added_recipes, removed_recipes,
+        profile_changed, editor_changed, name_changed, runtime_changed,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,6 +315,51 @@ mod tests {
         assert_eq!(restored.name, "original");
         assert_eq!(restored.runtime, "node");
 
+        let _ = std::fs::remove_dir_all(snapshots_dir(pid).unwrap());
+    }
+
+    #[test]
+    fn test_preview_rollback_shows_diff_against_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_path = dir.path().to_str().unwrap();
+        let pid = "test-snap-preview";
+
+        let m1 = ProjectManifest {
+            name: "v1".to_string(),
+            runtime: "node".to_string(),
+            technologies: vec!["nodejs".to_string()],
+            ..Default::default()
+        };
+        manifest::save_manifest(project_path, &m1).unwrap();
+        save_snapshot(pid, project_path).unwrap();
+
+        let m2 = ProjectManifest {
+            name: "v2".to_string(),
+            runtime: "python".to_string(),
+            technologies: vec!["python".to_string(), "fastapi".to_string()],
+            recipes_applied: vec!["docker".to_string()],
+            ..Default::default()
+        };
+        manifest::save_manifest(project_path, &m2).unwrap();
+
+        let preview = preview_rollback(pid, project_path, 1).unwrap();
+        assert_eq!(preview.target_version, 1);
+        assert!(preview.current_manifest_exists);
+        assert!(preview.added_techs.contains(&"nodejs".to_string()));
+        assert!(preview.removed_techs.contains(&"python".to_string()));
+        assert!(preview.removed_recipes.contains(&"docker".to_string()));
+        assert_eq!(preview.name_changed, Some(("v2".into(), "v1".into())));
+        assert_eq!(preview.runtime_changed, Some(("python".into(), "node".into())));
+
+        let _ = std::fs::remove_dir_all(snapshots_dir(pid).unwrap());
+    }
+
+    #[test]
+    fn test_preview_rollback_missing_snapshot_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid = "test-snap-preview-missing";
+        let result = preview_rollback(pid, dir.path().to_str().unwrap(), 99);
+        assert!(result.is_err());
         let _ = std::fs::remove_dir_all(snapshots_dir(pid).unwrap());
     }
 

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,5 +1,6 @@
 // Fundacional
 pub mod error;
+pub mod errors;
 pub mod models;
 pub mod store;
 pub mod utils;

--- a/src-tauri/src/core/project/portable.rs
+++ b/src-tauri/src/core/project/portable.rs
@@ -107,6 +107,57 @@ pub fn validate_target_path(target: &str) -> Result<PathBuf, NexenvError> {
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportPreview {
+    pub name: String,
+    pub description: Option<String>,
+    pub runtimes: Vec<RuntimeConfig>,
+    pub tags: Vec<String>,
+    pub template_id: Option<String>,
+    pub env_keys: Vec<String>,
+    pub has_manifest: bool,
+    pub target_path: String,
+    pub target_exists: bool,
+    pub target_has_files: bool,
+    pub conflict_with_existing: bool,
+}
+
+/// Devuelve un resumen de lo que haria un import sin tocar nada en disco ni en el store.
+pub fn preview_import(json: &str, target_path: &str) -> Result<ImportPreview, NexenvError> {
+    let validated = validate_target_path(target_path)?;
+    let target = validated.to_string_lossy().to_string();
+
+    let export: NexenvExport = serde_json::from_str(json)?;
+
+    let target_path_obj = Path::new(&target);
+    let target_exists = target_path_obj.exists();
+    let target_has_files = if target_exists && target_path_obj.is_dir() {
+        std::fs::read_dir(target_path_obj)
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    let projects = store::get().list_projects()?;
+    let conflict_with_existing = projects.iter().any(|p| p.path == target);
+
+    Ok(ImportPreview {
+        name: export.project.name,
+        description: export.project.description,
+        runtimes: export.project.runtimes,
+        tags: export.project.tags,
+        template_id: export.project.template_id,
+        env_keys: export.project.env_keys,
+        has_manifest: export.manifest.is_some(),
+        target_path: target,
+        target_exists,
+        target_has_files,
+        conflict_with_existing,
+    })
+}
+
 /// Importa un proyecto desde JSON portable (.nexenv)
 pub fn import_project(json: &str, target_path: &str) -> Result<Project, NexenvError> {
     let validated = validate_target_path(target_path)?;

--- a/src-tauri/src/core/recipes/mod.rs
+++ b/src-tauri/src/core/recipes/mod.rs
@@ -51,6 +51,9 @@ pub fn list_recipes() -> Vec<Recipe> {
         recipe_ci_github(),
         recipe_linting_biome(),
         recipe_database_prisma(),
+        recipe_auth_jwt(),
+        recipe_database_sqlalchemy(),
+        recipe_monitoring(),
     ]
 }
 
@@ -372,6 +375,369 @@ model User {
     }
 }
 
+fn recipe_auth_jwt() -> Recipe {
+    Recipe {
+        id: "auth-jwt".to_string(),
+        name: "JWT Auth".to_string(),
+        description: "Autenticacion JWT con refresh tokens (Express/Fastify)".to_string(),
+        category: "auth".to_string(),
+        files_to_create: vec![
+            RecipeFile {
+                path: "src/auth/jwt.ts".to_string(),
+                content: r#"import jwt from 'jsonwebtoken';
+
+const ACCESS_SECRET = process.env.JWT_ACCESS_SECRET || 'change-me-access';
+const REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'change-me-refresh';
+const ACCESS_TTL = process.env.JWT_ACCESS_TTL || '15m';
+const REFRESH_TTL = process.env.JWT_REFRESH_TTL || '7d';
+
+export interface AccessPayload { sub: string; email?: string; }
+export interface RefreshPayload { sub: string; jti: string; }
+
+export function signAccess(payload: AccessPayload): string {
+  return jwt.sign(payload, ACCESS_SECRET, { expiresIn: ACCESS_TTL });
+}
+
+export function signRefresh(payload: RefreshPayload): string {
+  return jwt.sign(payload, REFRESH_SECRET, { expiresIn: REFRESH_TTL });
+}
+
+export function verifyAccess(token: string): AccessPayload {
+  return jwt.verify(token, ACCESS_SECRET) as AccessPayload;
+}
+
+export function verifyRefresh(token: string): RefreshPayload {
+  return jwt.verify(token, REFRESH_SECRET) as RefreshPayload;
+}
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "src/auth/middleware.ts".to_string(),
+                content: r#"import type { Request, Response, NextFunction } from 'express';
+import { verifyAccess } from './jwt';
+
+declare module 'express-serve-static-core' {
+  interface Request { user?: { sub: string; email?: string }; }
+}
+
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'missing token' });
+  try {
+    req.user = verifyAccess(token);
+    next();
+  } catch {
+    return res.status(401).json({ error: 'invalid or expired token' });
+  }
+}
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "src/auth/routes.ts".to_string(),
+                content: r#"import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import { signAccess, signRefresh, verifyRefresh } from './jwt';
+
+export const authRouter = Router();
+
+// POST /auth/login — sustituir validacion por la propia
+authRouter.post('/login', (req, res) => {
+  const { email, password } = req.body ?? {};
+  if (!email || !password) return res.status(400).json({ error: 'missing credentials' });
+  // TODO: validar contra base de datos
+  const userId = 'user-id-from-db';
+  const accessToken = signAccess({ sub: userId, email });
+  const refreshToken = signRefresh({ sub: userId, jti: randomUUID() });
+  res.json({ accessToken, refreshToken });
+});
+
+// POST /auth/refresh — emite nuevo access token
+authRouter.post('/refresh', (req, res) => {
+  const { refreshToken } = req.body ?? {};
+  if (!refreshToken) return res.status(400).json({ error: 'missing refresh token' });
+  try {
+    const payload = verifyRefresh(refreshToken);
+    const accessToken = signAccess({ sub: payload.sub });
+    res.json({ accessToken });
+  } catch {
+    res.status(401).json({ error: 'invalid refresh token' });
+  }
+});
+
+// POST /auth/logout — el cliente debe descartar tokens; aqui se podria revocar en una blacklist
+authRouter.post('/logout', (_req, res) => {
+  res.status(204).send();
+});
+"#.to_string(),
+            },
+        ],
+        deps_to_install: vec!["jsonwebtoken".to_string(), "express".to_string()],
+        dev_deps_to_install: vec![
+            "@types/jsonwebtoken".to_string(),
+            "@types/express".to_string(),
+        ],
+        env_vars_to_add: [
+            ("JWT_ACCESS_SECRET".to_string(), "change-me-access".to_string()),
+            ("JWT_REFRESH_SECRET".to_string(), "change-me-refresh".to_string()),
+            ("JWT_ACCESS_TTL".to_string(), "15m".to_string()),
+            ("JWT_REFRESH_TTL".to_string(), "7d".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+        scripts_to_add: HashMap::new(),
+    }
+}
+
+fn recipe_database_sqlalchemy() -> Recipe {
+    Recipe {
+        id: "database-sqlalchemy".to_string(),
+        name: "SQLAlchemy + Alembic".to_string(),
+        description: "ORM SQLAlchemy con Postgres y migraciones Alembic".to_string(),
+        category: "database".to_string(),
+        files_to_create: vec![
+            RecipeFile {
+                path: "app/db/__init__.py".to_string(),
+                content: String::new(),
+            },
+            RecipeFile {
+                path: "app/db/session.py".to_string(),
+                content: r#"import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+psycopg://user:password@localhost:5432/mydb",
+)
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "app/db/models.py".to_string(),
+                content: r#"from datetime import datetime
+from sqlalchemy import Column, DateTime, String
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+
+from .session import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String, unique=True, nullable=False, index=True)
+    name = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "alembic.ini".to_string(),
+                content: r#"[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+psycopg://user:password@localhost:5432/mydb
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "alembic/env.py".to_string(),
+                content: r#"from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.db.session import Base
+from app.db import models  # noqa: F401  asegura que los modelos se registren
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "alembic/script.py.mako".to_string(),
+                content: r#""""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "alembic/versions/.gitkeep".to_string(),
+                content: String::new(),
+            },
+        ],
+        deps_to_install: vec![
+            "sqlalchemy>=2.0".to_string(),
+            "psycopg[binary]>=3.1".to_string(),
+            "alembic>=1.13".to_string(),
+        ],
+        dev_deps_to_install: vec![],
+        env_vars_to_add: [(
+            "DATABASE_URL".to_string(),
+            "postgresql+psycopg://user:password@localhost:5432/mydb".to_string(),
+        )]
+        .into_iter()
+        .collect(),
+        scripts_to_add: HashMap::new(),
+    }
+}
+
+fn recipe_monitoring() -> Recipe {
+    Recipe {
+        id: "monitoring".to_string(),
+        name: "Health + Structured Logging".to_string(),
+        description: "Endpoint /health y logging estructurado JSON (pino/structlog)".to_string(),
+        category: "monitoring".to_string(),
+        files_to_create: vec![
+            RecipeFile {
+                path: "src/monitoring/health.ts".to_string(),
+                content: r#"import type { Request, Response } from 'express';
+
+const STARTED_AT = Date.now();
+const VERSION = process.env.APP_VERSION || '0.0.0';
+
+export function healthHandler(_req: Request, res: Response) {
+  res.json({
+    status: 'ok',
+    version: VERSION,
+    uptimeSeconds: Math.floor((Date.now() - STARTED_AT) / 1000),
+    db: true,
+  });
+}
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "src/monitoring/logger.ts".to_string(),
+                content: r#"import pino from 'pino';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+  base: { service: process.env.SERVICE_NAME || 'app' },
+  timestamp: pino.stdTimeFunctions.isoTime,
+});
+
+export type Logger = typeof logger;
+"#.to_string(),
+            },
+            RecipeFile {
+                path: "src/monitoring/README.md".to_string(),
+                content: r#"# Monitoring
+
+## Endpoints
+- `GET /health` — devuelve `{ status, version, uptimeSeconds, db }`. Conectalo con `app.get('/health', healthHandler)`.
+
+## Logger
+- Importa `logger` desde `src/monitoring/logger.ts`.
+- Usa `logger.info({ event: 'user.login', userId })` con campos estructurados, no strings concatenados.
+- Configurable con `LOG_LEVEL` (default `info`) y `SERVICE_NAME`.
+"#.to_string(),
+            },
+        ],
+        deps_to_install: vec!["pino".to_string()],
+        dev_deps_to_install: vec![],
+        env_vars_to_add: [
+            ("APP_VERSION".to_string(), "0.0.0".to_string()),
+            ("LOG_LEVEL".to_string(), "info".to_string()),
+            ("SERVICE_NAME".to_string(), "app".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+        scripts_to_add: HashMap::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -379,7 +745,7 @@ mod tests {
     #[test]
     fn test_list_recipes() {
         let recipes = list_recipes();
-        assert_eq!(recipes.len(), 6);
+        assert_eq!(recipes.len(), 9);
     }
 
     #[test]
@@ -431,5 +797,60 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = apply_recipe(dir.path().to_str().unwrap(), "nonexistent");
         assert!(result.is_err());
+    }
+
+    // --- 3 recipes nuevas (G4 del plan v1.0.0) ---
+
+    #[test]
+    fn test_recipe_auth_jwt_apply_creates_files_and_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = apply_recipe(dir.path().to_str().unwrap(), "auth-jwt").unwrap();
+        assert!(result.files_created.contains(&"src/auth/jwt.ts".to_string()));
+        assert!(result.files_created.contains(&"src/auth/middleware.ts".to_string()));
+        assert!(result.files_created.contains(&"src/auth/routes.ts".to_string()));
+        assert!(result.env_vars_added.contains(&"JWT_ACCESS_SECRET".to_string()));
+        assert!(result.env_vars_added.contains(&"JWT_REFRESH_SECRET".to_string()));
+
+        let routes = std::fs::read_to_string(dir.path().join("src/auth/routes.ts")).unwrap();
+        assert!(routes.contains("/login"));
+        assert!(routes.contains("/refresh"));
+        assert!(routes.contains("/logout"));
+    }
+
+    #[test]
+    fn test_recipe_database_sqlalchemy_apply_creates_alembic_skeleton() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = apply_recipe(dir.path().to_str().unwrap(), "database-sqlalchemy").unwrap();
+        assert!(result.files_created.contains(&"alembic.ini".to_string()));
+        assert!(result.files_created.contains(&"alembic/env.py".to_string()));
+        assert!(result.files_created.contains(&"app/db/session.py".to_string()));
+        assert!(result.files_created.contains(&"app/db/models.py".to_string()));
+        assert!(result.env_vars_added.contains(&"DATABASE_URL".to_string()));
+
+        let session = std::fs::read_to_string(dir.path().join("app/db/session.py")).unwrap();
+        assert!(session.contains("create_engine"));
+        assert!(session.contains("DATABASE_URL"));
+        let env_py = std::fs::read_to_string(dir.path().join("alembic/env.py")).unwrap();
+        assert!(env_py.contains("target_metadata = Base.metadata"));
+    }
+
+    #[test]
+    fn test_recipe_monitoring_apply_creates_health_and_logger() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = apply_recipe(dir.path().to_str().unwrap(), "monitoring").unwrap();
+        assert!(result.files_created.contains(&"src/monitoring/health.ts".to_string()));
+        assert!(result.files_created.contains(&"src/monitoring/logger.ts".to_string()));
+        assert!(result.env_vars_added.contains(&"LOG_LEVEL".to_string()));
+
+        let health = std::fs::read_to_string(dir.path().join("src/monitoring/health.ts")).unwrap();
+        assert!(health.contains("status"));
+        assert!(health.contains("uptimeSeconds"));
+    }
+
+    #[test]
+    fn test_new_recipes_visible_via_get() {
+        assert!(get_recipe("auth-jwt").is_some());
+        assert!(get_recipe("database-sqlalchemy").is_some());
+        assert!(get_recipe("monitoring").is_some());
     }
 }

--- a/src-tauri/src/core/runtime/activate.rs
+++ b/src-tauri/src/core/runtime/activate.rs
@@ -1,0 +1,85 @@
+use crate::core::models::project::RuntimeConfig;
+use crate::core::runtime::managers::{detect_managers, resolve_bin_paths, Manager};
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[derive(Debug, Clone)]
+pub struct Activation {
+    pub bin_paths: Vec<PathBuf>,
+    pub managers_detected: Vec<Manager>,
+    pub elapsed_ms: u128,
+}
+
+impl Activation {
+    pub fn prefix_path(&self, current_path: &str) -> String {
+        prefix_path(&self.bin_paths, current_path)
+    }
+}
+
+pub fn activate(runtimes: &[RuntimeConfig]) -> Activation {
+    let start = Instant::now();
+    let home = home_dir();
+    let managers = detect_managers(&home);
+    let bin_paths = resolve_bin_paths(runtimes, &managers, &home);
+    Activation {
+        bin_paths,
+        managers_detected: managers,
+        elapsed_ms: start.elapsed().as_millis(),
+    }
+}
+
+fn home_dir() -> PathBuf {
+    if let Some(h) = std::env::var_os("HOME") {
+        return PathBuf::from(h);
+    }
+    if let Some(h) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(h);
+    }
+    PathBuf::from(".")
+}
+
+pub fn prefix_path(extras: &[PathBuf], current_path: &str) -> String {
+    let sep = if cfg!(target_os = "windows") { ";" } else { ":" };
+    if extras.is_empty() {
+        return current_path.to_string();
+    }
+    let mut parts: Vec<String> = extras
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    if !current_path.is_empty() {
+        parts.push(current_path.to_string());
+    }
+    parts.join(sep)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_path_empty_extras_returns_current() {
+        assert_eq!(prefix_path(&[], "/usr/bin"), "/usr/bin");
+    }
+
+    #[test]
+    fn prefix_path_uses_correct_separator() {
+        let extras = vec![PathBuf::from("/opt/a"), PathBuf::from("/opt/b")];
+        let got = prefix_path(&extras, "/usr/bin");
+        let sep = if cfg!(target_os = "windows") { ";" } else { ":" };
+        let expected = format!("/opt/a{sep}/opt/b{sep}/usr/bin");
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn prefix_path_skips_empty_current() {
+        let extras = vec![PathBuf::from("/opt/a")];
+        assert_eq!(prefix_path(&extras, ""), "/opt/a");
+    }
+
+    #[test]
+    fn activate_with_empty_runtimes_returns_no_paths() {
+        let act = activate(&[]);
+        assert!(act.bin_paths.is_empty());
+    }
+}

--- a/src-tauri/src/core/runtime/managers.rs
+++ b/src-tauri/src/core/runtime/managers.rs
@@ -1,0 +1,228 @@
+use crate::core::models::project::RuntimeConfig;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Manager {
+    Nvm,
+    Fnm,
+    Pyenv,
+    Rustup,
+}
+
+pub fn detect_managers(home: &Path) -> Vec<Manager> {
+    let mut found = Vec::new();
+    if home.join(".nvm").is_dir() {
+        found.push(Manager::Nvm);
+    }
+    if home.join(".fnm").is_dir() || home.join(".local/share/fnm").is_dir() {
+        found.push(Manager::Fnm);
+    }
+    if home.join(".pyenv").is_dir() {
+        found.push(Manager::Pyenv);
+    }
+    if home.join(".rustup").is_dir() {
+        found.push(Manager::Rustup);
+    }
+    found
+}
+
+pub fn nvm_bin_path(home: &Path, version: &str) -> PathBuf {
+    let v = normalize_node_version(version);
+    if cfg!(target_os = "windows") {
+        home.join(".nvm").join("versions").join("node").join(&v)
+    } else {
+        home.join(".nvm").join("versions").join("node").join(&v).join("bin")
+    }
+}
+
+pub fn fnm_bin_path(home: &Path, version: &str) -> PathBuf {
+    let v = normalize_node_version(version);
+    let base = if home.join(".fnm").is_dir() {
+        home.join(".fnm")
+    } else {
+        home.join(".local/share/fnm")
+    };
+    if cfg!(target_os = "windows") {
+        base.join("node-versions").join(&v).join("installation")
+    } else {
+        base.join("node-versions").join(&v).join("installation").join("bin")
+    }
+}
+
+pub fn pyenv_bin_path(home: &Path, version: &str) -> PathBuf {
+    if cfg!(target_os = "windows") {
+        home.join(".pyenv").join("pyenv-win").join("versions").join(version)
+    } else {
+        home.join(".pyenv").join("versions").join(version).join("bin")
+    }
+}
+
+pub fn rustup_bin_path(home: &Path, toolchain: &str) -> PathBuf {
+    let host = rustup_host_triple();
+    let full = if toolchain.contains('-') {
+        toolchain.to_string()
+    } else {
+        format!("{}-{}", toolchain, host)
+    };
+    home.join(".rustup").join("toolchains").join(full).join("bin")
+}
+
+pub fn resolve_bin_paths(
+    runtimes: &[RuntimeConfig],
+    managers: &[Manager],
+    home: &Path,
+) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for rc in runtimes {
+        let lower = rc.runtime.to_ascii_lowercase();
+        let candidates: Vec<PathBuf> = match lower.as_str() {
+            "node" | "nodejs" => {
+                let mut c = Vec::new();
+                if managers.contains(&Manager::Fnm) {
+                    c.push(fnm_bin_path(home, &rc.version));
+                }
+                if managers.contains(&Manager::Nvm) {
+                    c.push(nvm_bin_path(home, &rc.version));
+                }
+                c
+            }
+            "python" | "python3" => {
+                if managers.contains(&Manager::Pyenv) {
+                    vec![pyenv_bin_path(home, &rc.version)]
+                } else {
+                    Vec::new()
+                }
+            }
+            "rust" | "rustc" => {
+                if managers.contains(&Manager::Rustup) {
+                    vec![rustup_bin_path(home, &rc.version)]
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        };
+        for c in candidates {
+            if c.is_dir() {
+                out.push(c);
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn normalize_node_version(v: &str) -> String {
+    let trimmed = v.trim();
+    if trimmed.starts_with('v') {
+        trimmed.to_string()
+    } else {
+        format!("v{}", trimmed)
+    }
+}
+
+fn rustup_host_triple() -> &'static str {
+    if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        "x86_64-pc-windows-msvc"
+    } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "aarch64-apple-darwin"
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        "x86_64-apple-darwin"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        "x86_64-unknown-linux-gnu"
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        "aarch64-unknown-linux-gnu"
+    } else {
+        "unknown-unknown-unknown"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_node_version_with_or_without_v() {
+        assert_eq!(normalize_node_version("22.16.0"), "v22.16.0");
+        assert_eq!(normalize_node_version("v22.16.0"), "v22.16.0");
+        assert_eq!(normalize_node_version("  22.0.0  "), "v22.0.0");
+    }
+
+    #[test]
+    fn nvm_path_uses_v_prefix() {
+        let home = Path::new("/home/u");
+        let p = nvm_bin_path(home, "22.16.0");
+        let s = p.to_string_lossy();
+        assert!(s.contains("v22.16.0"), "got: {s}");
+        assert!(s.contains(".nvm"));
+    }
+
+    #[test]
+    fn rustup_appends_host_triple_when_missing() {
+        let home = Path::new("/home/u");
+        let p = rustup_bin_path(home, "stable");
+        let s = p.to_string_lossy();
+        assert!(s.contains("stable-"), "got: {s}");
+        assert!(s.contains(".rustup"));
+    }
+
+    #[test]
+    fn rustup_keeps_full_toolchain_name() {
+        let home = Path::new("/home/u");
+        let p = rustup_bin_path(home, "stable-x86_64-unknown-linux-gnu");
+        let s = p.to_string_lossy();
+        assert!(s.contains("stable-x86_64-unknown-linux-gnu"), "got: {s}");
+    }
+
+    #[test]
+    fn detect_managers_empty_when_nothing_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let found = detect_managers(tmp.path());
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn detect_managers_finds_nvm_and_pyenv() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".nvm")).unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pyenv")).unwrap();
+        let found = detect_managers(tmp.path());
+        assert!(found.contains(&Manager::Nvm));
+        assert!(found.contains(&Manager::Pyenv));
+        assert!(!found.contains(&Manager::Fnm));
+        assert!(!found.contains(&Manager::Rustup));
+    }
+
+    #[test]
+    fn resolve_bin_paths_returns_existing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let bin_dir = if cfg!(target_os = "windows") {
+            home.join(".nvm").join("versions").join("node").join("v22.16.0")
+        } else {
+            home.join(".nvm").join("versions").join("node").join("v22.16.0").join("bin")
+        };
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(home.join(".nvm")).unwrap();
+
+        let runtimes = vec![RuntimeConfig {
+            runtime: "node".into(),
+            version: "22.16.0".into(),
+        }];
+        let managers = vec![Manager::Nvm];
+        let paths = resolve_bin_paths(&runtimes, &managers, home);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], bin_dir);
+    }
+
+    #[test]
+    fn resolve_bin_paths_skips_unknown_runtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtimes = vec![RuntimeConfig {
+            runtime: "go".into(),
+            version: "1.22".into(),
+        }];
+        let paths = resolve_bin_paths(&runtimes, &[Manager::Nvm], tmp.path());
+        assert!(paths.is_empty());
+    }
+}

--- a/src-tauri/src/core/runtime/mod.rs
+++ b/src-tauri/src/core/runtime/mod.rs
@@ -1,5 +1,7 @@
+pub mod activate;
 pub mod docker;
 pub mod git;
+pub mod managers;
 pub mod ports;
 pub mod processes;
 pub mod scripts;

--- a/src-tauri/src/core/templates/mod.rs
+++ b/src-tauri/src/core/templates/mod.rs
@@ -96,6 +96,7 @@ mod tests {
     use super::*;
     use crate::core::store;
     use serial_test::serial;
+    use std::path::PathBuf;
 
     /// Elimina un proyecto del projects.json por su path
     fn cleanup_by_path(path: &str) {
@@ -108,62 +109,195 @@ mod tests {
         }
     }
 
+    /// Helper de smoke test por template. Comprueba:
+    /// 1. `create_from_template` devuelve Ok
+    /// 2. Todos los archivos esperados existen
+    /// 3. El manifest Nexenv se genero (es prerequisito para que open/recipes funcionen)
+    /// 4. La sustitucion de {{project_name}} ocurrio (si el template lo usa)
+    fn run_template_smoke(template_id: &str, name: &str, expected: &[&str]) -> PathBuf {
+        crate::core::store::init_test_store();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        let path_str = path.to_str().unwrap().to_string();
+
+        let result = create_from_template(template_id, &path_str, name);
+        assert!(
+            result.is_ok(),
+            "create_from_template({}) fallo: {:?}",
+            template_id,
+            result.err()
+        );
+
+        for f in expected {
+            assert!(
+                path.join(f).exists(),
+                "falta archivo '{}' en template '{}'",
+                f,
+                template_id
+            );
+        }
+
+        let manifest = crate::core::manifest::load_manifest(&path_str)
+            .expect("load_manifest no debe fallar")
+            .unwrap_or_else(|| panic!("manifest Nexenv no generado para '{}'", template_id));
+        assert_eq!(manifest.name, name, "manifest.name debe coincidir con el nombre");
+
+        // Mantener tempdir vivo retornando su path (el dir se borra al salir del scope).
+        let kept = dir.keep();
+        let owned_path = kept.join(name);
+        cleanup_by_path(&path_str);
+        owned_path
+    }
+
     #[test]
     fn test_all_templates_exist() {
         let templates = all_templates();
         assert_eq!(templates.len(), 7);
     }
 
+    // --- 7 smoke tests por template ---
+
     #[test]
     #[serial(disk)]
     fn test_node_express_template_generates_files() {
-        crate::core::store::init_test_store();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test-project");
-        let path_str = path.to_str().unwrap();
-        let result = create_from_template("node-express", path_str, "test-project");
-        assert!(result.is_ok());
-        assert!(path.join("package.json").exists());
-        assert!(path.join(".gitignore").exists());
-        assert!(path.join("README.md").exists());
-        assert!(path.join("src/index.js").exists());
-
+        let path = run_template_smoke(
+            "node-express",
+            "test-project",
+            &["package.json", ".gitignore", "README.md", "src/index.js"],
+        );
         let pkg = std::fs::read_to_string(path.join("package.json")).unwrap();
-        assert!(pkg.contains("test-project"));
-
-        cleanup_by_path(path_str);
+        let parsed: serde_json::Value = serde_json::from_str(&pkg)
+            .expect("package.json debe ser JSON valido");
+        assert_eq!(parsed.get("name").and_then(|v| v.as_str()), Some("test-project"));
+        assert!(parsed.get("scripts").is_some(), "package.json debe tener 'scripts'");
     }
 
     #[test]
     #[serial(disk)]
     fn test_react_vite_template_generates_files() {
-        crate::core::store::init_test_store();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("my-react-app");
-        let path_str = path.to_str().unwrap();
-        let result = create_from_template("react-vite", path_str, "my-react-app");
-        assert!(result.is_ok(), "Failed: {:?}", result.err());
-        assert!(path.join("package.json").exists());
-        assert!(path.join("src/main.tsx").exists());
-        assert!(path.join("src/App.tsx").exists());
-        assert!(path.join("vite.config.ts").exists());
-
-        cleanup_by_path(path_str);
+        let path = run_template_smoke(
+            "react-vite",
+            "my-react-app",
+            &["package.json", "src/main.tsx", "src/App.tsx", "vite.config.ts"],
+        );
+        let pkg = std::fs::read_to_string(path.join("package.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&pkg)
+            .expect("package.json debe ser JSON valido");
+        let deps = parsed.get("dependencies").or_else(|| parsed.get("devDependencies"))
+            .expect("package.json debe declarar dependencies o devDependencies");
+        assert!(deps.is_object());
     }
 
     #[test]
     #[serial(disk)]
     fn test_python_fastapi_template() {
-        crate::core::store::init_test_store();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("my-api");
-        let path_str = path.to_str().unwrap();
-        let result = create_from_template("python-fastapi", path_str, "my-api");
-        assert!(result.is_ok());
-        assert!(path.join("requirements.txt").exists());
-        assert!(path.join("app/main.py").exists());
+        let path = run_template_smoke(
+            "python-fastapi",
+            "my-api",
+            &["requirements.txt", "app/main.py"],
+        );
+        let reqs = std::fs::read_to_string(path.join("requirements.txt")).unwrap();
+        assert!(!reqs.trim().is_empty(), "requirements.txt no puede estar vacio");
+        assert!(reqs.to_lowercase().contains("fastapi"),
+            "requirements.txt de FastAPI debe declarar fastapi: {}", reqs);
+    }
 
-        cleanup_by_path(path_str);
+    #[test]
+    #[serial(disk)]
+    fn test_python_django_template() {
+        let path = run_template_smoke(
+            "python-django",
+            "my-django",
+            &["requirements.txt", "manage.py", ".gitignore", "README.md"],
+        );
+        let reqs = std::fs::read_to_string(path.join("requirements.txt")).unwrap();
+        assert!(reqs.to_lowercase().contains("django"),
+            "requirements.txt de Django debe declarar django: {}", reqs);
+        let manage = std::fs::read_to_string(path.join("manage.py")).unwrap();
+        assert!(manage.contains("DJANGO_SETTINGS_MODULE") || manage.contains("django"),
+            "manage.py debe ser un launcher Django");
+    }
+
+    #[test]
+    #[serial(disk)]
+    fn test_fullstack_react_python_template() {
+        let path = run_template_smoke(
+            "fullstack-react-python",
+            "my-fullstack",
+            &[
+                "frontend/package.json",
+                "frontend/src/App.tsx",
+                "backend/requirements.txt",
+                "backend/app/main.py",
+            ],
+        );
+        let frontend_pkg = std::fs::read_to_string(path.join("frontend/package.json")).unwrap();
+        let _: serde_json::Value = serde_json::from_str(&frontend_pkg)
+            .expect("frontend/package.json debe ser JSON valido");
+        let backend_reqs = std::fs::read_to_string(path.join("backend/requirements.txt")).unwrap();
+        assert!(!backend_reqs.trim().is_empty(), "backend/requirements.txt no puede estar vacio");
+    }
+
+    #[test]
+    #[serial(disk)]
+    fn test_rust_cli_template() {
+        let path = run_template_smoke(
+            "rust-cli",
+            "my-rust-cli",
+            &["Cargo.toml", "src/main.rs", ".gitignore", "README.md"],
+        );
+        let cargo = std::fs::read_to_string(path.join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("[package]"), "Cargo.toml debe tener seccion [package]");
+        assert!(cargo.contains("name ="), "Cargo.toml debe declarar 'name ='");
+        let main_rs = std::fs::read_to_string(path.join("src/main.rs")).unwrap();
+        assert!(main_rs.contains("fn main"), "src/main.rs debe tener fn main");
+    }
+
+    #[test]
+    #[serial(disk)]
+    fn test_docker_compose_template() {
+        let path = run_template_smoke(
+            "docker-compose",
+            "my-stack",
+            &["docker-compose.yml", ".gitignore", "README.md", ".env.example"],
+        );
+        let compose = std::fs::read_to_string(path.join("docker-compose.yml")).unwrap();
+        let parsed: serde_yml::Value = serde_yml::from_str(&compose)
+            .expect("docker-compose.yml debe ser YAML valido");
+        assert!(parsed.get("services").is_some(),
+            "docker-compose.yml debe tener clave 'services'");
+    }
+
+    // --- Parametrizado: cobertura de TODOS los templates en una sola pasada ---
+
+    #[test]
+    #[serial(disk)]
+    fn test_every_template_generates_a_valid_nexenv_manifest() {
+        for tmpl in all_templates() {
+            crate::core::store::init_test_store();
+            let dir = tempfile::tempdir().unwrap();
+            let name = format!("smoke-{}", tmpl.id);
+            let path = dir.path().join(&name);
+            let path_str = path.to_str().unwrap().to_string();
+
+            let result = create_from_template(tmpl.id, &path_str, &name);
+            assert!(
+                result.is_ok(),
+                "template '{}' fallo en generacion: {:?}",
+                tmpl.id,
+                result.err()
+            );
+
+            let manifest = crate::core::manifest::load_manifest(&path_str)
+                .expect("load_manifest no debe fallar");
+            assert!(
+                manifest.is_some(),
+                "template '{}' no genero manifest Nexenv",
+                tmpl.id
+            );
+
+            cleanup_by_path(&path_str);
+        }
     }
 
     #[test]

--- a/src-tauri/src/core/utils/editor.rs
+++ b/src-tauri/src/core/utils/editor.rs
@@ -21,6 +21,15 @@ pub fn find_workspace_file(project_path: &str) -> Option<String> {
 /// detecta si hay .code-workspace, y abre el proyecto.
 /// Centraliza la lógica de commands/projects.rs, commands/shell.rs y bin/cli.rs.
 pub fn open_in_editor(project_path: &str, editor: &str) -> Result<(), String> {
+    open_in_editor_with_env(project_path, editor, &std::collections::HashMap::new())
+}
+
+/// Igual que open_in_editor pero permite inyectar env vars adicionales (PATH, etc).
+pub fn open_in_editor_with_env(
+    project_path: &str,
+    editor: &str,
+    extra_env: &std::collections::HashMap<String, String>,
+) -> Result<(), String> {
     if !ALLOWED_EDITORS.contains(&editor) {
         return Err(format!(
             "Editor '{}' no permitido. Editores disponibles: {}",
@@ -32,13 +41,15 @@ pub fn open_in_editor(project_path: &str, editor: &str) -> Result<(), String> {
     let editor_bin = find_editor_in_path(editor)
         .ok_or_else(|| format!("Editor '{}' no encontrado en PATH", editor))?;
 
-    // Si existe un .code-workspace, abrir ese en vez de la carpeta
     let open_target = find_workspace_file(project_path)
         .unwrap_or_else(|| project_path.to_string());
 
-    std::process::Command::new(&editor_bin)
-        .arg(&open_target)
-        .spawn()
+    let mut cmd = std::process::Command::new(&editor_bin);
+    cmd.arg(&open_target);
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.spawn()
         .map_err(|e| format!("Error abriendo {}: {}", editor, e))?;
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,7 @@ pub fn run() {
             templates::create_from_template,
             // Portable
             portable::export_project,
+            portable::preview_import,
             portable::import_project,
             // VSCode
             vscode::generate_vscode_workspace,
@@ -95,6 +96,7 @@ pub fn run() {
             versioning::save_snapshot,
             versioning::list_snapshots,
             versioning::diff_snapshots,
+            versioning::preview_rollback,
             versioning::rollback_snapshot,
             // Snapshots
             snapshots::take_env_snapshot,

--- a/src/components/dashboard/ImportProjectModal.tsx
+++ b/src/components/dashboard/ImportProjectModal.tsx
@@ -3,6 +3,8 @@ import * as api from "@/lib/tauri";
 import PathInput from "@/components/ui/PathInput";
 import { Spinner } from "@/components/ui/Spinner";
 import { toast } from "@/components/ui/Toast";
+import PreviewConfirmModal, { type PreviewSection } from "@/components/ui/PreviewConfirmModal";
+import type { ImportPreview } from "@/types/portable";
 
 interface ImportProjectModalProps {
   isOpen: boolean;
@@ -18,7 +20,9 @@ export default function ImportProjectModal({
   onSuccess,
 }: ImportProjectModalProps) {
   const [path, setPath] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [preview, setPreview] = useState<ImportPreview | null>(null);
+  const [applying, setApplying] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   if (!isOpen) return null;
@@ -32,23 +36,86 @@ export default function ImportProjectModal({
       return;
     }
 
-    setIsSubmitting(true);
+    setLoadingPreview(true);
     try {
-      await api.importProject(fileContent, path.trim());
+      const p = await api.previewImport(fileContent, path.trim());
+      setPreview(p);
+    } catch (err) {
+      toast.error(err);
+      setError(typeof err === "string" ? err : null);
+    } finally {
+      setLoadingPreview(false);
+    }
+  }
+
+  async function applyImport() {
+    if (!preview) return;
+    setApplying(true);
+    try {
+      await api.importProject(fileContent, preview.targetPath);
       toast.success("Proyecto importado correctamente");
       setPath("");
+      setPreview(null);
       onSuccess();
       onClose();
     } catch (err) {
-      setError(String(err));
-    } finally {
-      setIsSubmitting(false);
+      toast.error(err);
+      setApplying(false);
     }
+  }
+
+  function importSections(p: ImportPreview): PreviewSection[] {
+    const out: PreviewSection[] = [];
+    out.push({
+      label: "Proyecto a importar",
+      items: [
+        `Nombre: ${p.name}`,
+        ...(p.description ? [`Descripcion: ${p.description}`] : []),
+        `Tags: ${p.tags.length ? p.tags.join(", ") : "(ninguno)"}`,
+        `Manifest incluido: ${p.hasManifest ? "si" : "no"}`,
+      ],
+      tone: "neutral",
+    });
+    if (p.runtimes.length) {
+      out.push({
+        label: "Runtimes",
+        items: p.runtimes.map((r) => `${r.runtime} ${r.version}`),
+        tone: "added",
+      });
+    }
+    if (p.envKeys.length) {
+      out.push({
+        label: "Variables de entorno (solo nombres, sin valores)",
+        items: p.envKeys,
+        tone: "neutral",
+      });
+    }
+    out.push({
+      label: "Destino",
+      items: [
+        p.targetPath,
+        `La carpeta ${p.targetExists ? "existe" : "se creara"}`,
+        ...(p.targetHasFiles ? ["La carpeta contiene archivos"] : []),
+      ],
+      tone: p.targetHasFiles || p.conflictWithExisting ? "warning" : "neutral",
+    });
+    return out;
+  }
+
+  function importWarning(p: ImportPreview): string | undefined {
+    if (p.conflictWithExisting) {
+      return "Ya existe un proyecto registrado en esta ruta. El import sera rechazado por el backend.";
+    }
+    if (p.targetHasFiles) {
+      return "La carpeta destino contiene archivos. El proyecto se registrara, pero los archivos existentes no se modifican.";
+    }
+    return undefined;
   }
 
   function handleClose() {
     setPath("");
     setError(null);
+    setPreview(null);
     onClose();
   }
 
@@ -105,14 +172,27 @@ export default function ImportProjectModal({
             </button>
             <button
               type="submit"
-              disabled={isSubmitting}
+              disabled={loadingPreview}
               className="inline-flex items-center justify-center min-w-28 px-4 py-2 rounded-lg text-sm font-medium bg-success/10 text-success-light hover:bg-success/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              {isSubmitting ? <Spinner size="sm" className="text-success-light" /> : "Importar"}
+              {loadingPreview ? <Spinner size="sm" className="text-success-light" /> : "Vista previa"}
             </button>
           </div>
         </form>
       </div>
+
+      <PreviewConfirmModal
+        open={!!preview}
+        title="Confirmar import del proyecto"
+        subtitle="Revisa los detalles antes de aplicar."
+        sections={preview ? importSections(preview) : []}
+        warning={preview ? importWarning(preview) : undefined}
+        confirmLabel="Importar"
+        destructive={!!preview?.conflictWithExisting}
+        busy={applying}
+        onConfirm={applyImport}
+        onCancel={() => setPreview(null)}
+      />
     </div>
   );
 }

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import logo from "@/assets/logos/Log-bt.png";
 import "./Titlebar.css";
@@ -10,11 +11,16 @@ function detectOs(): "win" | "mac" | "linux" {
   return "win";
 }
 
+const tauri = isTauri();
+
+const safeWindow = () => (tauri ? getCurrentWindow() : null);
+
 export default function Titlebar() {
   const [os] = useState(detectOs);
   const [maximized, setMaximized] = useState(false);
 
   useEffect(() => {
+    if (!tauri) return;
     const w = getCurrentWindow();
     w.isMaximized().then(setMaximized).catch(() => {});
     const unlisten = w.onResized(() => {
@@ -33,15 +39,15 @@ export default function Titlebar() {
         <span className="titlebar__name" data-tauri-drag-region>Nexenv</span>
       </div>
 
-      {/* Window controls */}
-      {!isMac && (
+      {/* Window controls (solo en Tauri, no en navegador) */}
+      {!isMac && tauri && (
         <div className="titlebar__controls">
-          <button className="titlebar__btn" onClick={() => getCurrentWindow().minimize()}>
+          <button className="titlebar__btn" onClick={() => safeWindow()?.minimize()}>
             <svg width="10" height="1" viewBox="0 0 10 1">
               <rect width="10" height="1" fill="#7a7a9a" />
             </svg>
           </button>
-          <button className="titlebar__btn" onClick={() => getCurrentWindow().toggleMaximize()}>
+          <button className="titlebar__btn" onClick={() => safeWindow()?.toggleMaximize()}>
             {maximized ? (
               <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                 <rect x="2" y="0" width="8" height="8" stroke="#7a7a9a" strokeWidth="1" fill="none" />
@@ -53,7 +59,7 @@ export default function Titlebar() {
               </svg>
             )}
           </button>
-          <button className="titlebar__btn titlebar__btn--close" onClick={() => getCurrentWindow().close()}>
+          <button className="titlebar__btn titlebar__btn--close" onClick={() => safeWindow()?.close()}>
             <svg width="10" height="10" viewBox="0 0 10 10">
               <line x1="1" y1="1" x2="9" y2="9" stroke="#7a7a9a" strokeWidth="1.2" />
               <line x1="9" y1="1" x2="1" y2="9" stroke="#7a7a9a" strokeWidth="1.2" />

--- a/src/components/project/tabs/VersioningTab.tsx
+++ b/src/components/project/tabs/VersioningTab.tsx
@@ -1,13 +1,22 @@
 import { useCallback, useEffect, useState } from "react";
 import * as api from "@/lib/tauri";
-import type { Snapshot, SnapshotDiff } from "@/types/versioning";
+import type { Snapshot, SnapshotDiff, RollbackPreview } from "@/types/versioning";
+import PreviewConfirmModal, { type PreviewSection } from "@/components/ui/PreviewConfirmModal";
+import { toast } from "@/components/ui/Toast";
+
+interface RollbackState {
+  version: number;
+  preview: RollbackPreview | null;
+  loading: boolean;
+  applying: boolean;
+}
 
 export default function VersioningTab({ projectId }: { projectId: string; projectPath: string }) {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [diff, setDiff] = useState<SnapshotDiff | null>(null);
-  const [confirmRollback, setConfirmRollback] = useState<number | null>(null);
+  const [rollback, setRollback] = useState<RollbackState | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -45,14 +54,42 @@ export default function VersioningTab({ projectId }: { projectId: string; projec
     }
   }
 
-  async function handleRollback(version: number) {
+  async function openRollbackPreview(version: number) {
+    setRollback({ version, preview: null, loading: true, applying: false });
     try {
-      await api.rollbackSnapshot(projectId, version);
-      setConfirmRollback(null);
+      const preview = await api.previewRollback(projectId, version);
+      setRollback({ version, preview, loading: false, applying: false });
+    } catch (err) {
+      toast.error(err);
+      setRollback(null);
+    }
+  }
+
+  async function applyRollback() {
+    if (!rollback) return;
+    setRollback({ ...rollback, applying: true });
+    try {
+      await api.rollbackSnapshot(projectId, rollback.version);
+      toast.success(`Rollback a v${rollback.version} aplicado`);
+      setRollback(null);
       await load();
     } catch (err) {
-      setError(String(err));
+      toast.error(err);
+      setRollback({ ...rollback, applying: false });
     }
+  }
+
+  function rollbackSections(p: RollbackPreview): PreviewSection[] {
+    const out: PreviewSection[] = [];
+    if (p.addedTechs.length) out.push({ label: "Tecnologias que se anaden", items: p.addedTechs, tone: "added" });
+    if (p.removedTechs.length) out.push({ label: "Tecnologias que se quitan", items: p.removedTechs, tone: "removed" });
+    if (p.addedRecipes.length) out.push({ label: "Recipes que se anaden", items: p.addedRecipes, tone: "added" });
+    if (p.removedRecipes.length) out.push({ label: "Recipes que se quitan", items: p.removedRecipes, tone: "removed" });
+    if (p.profileChanged) out.push({ label: "Profile", items: [`${p.profileChanged[0]} → ${p.profileChanged[1]}`], tone: "changed" });
+    if (p.editorChanged) out.push({ label: "Editor", items: [`${p.editorChanged[0] ?? "(ninguno)"} → ${p.editorChanged[1] ?? "(ninguno)"}`], tone: "changed" });
+    if (p.nameChanged) out.push({ label: "Nombre", items: [`${p.nameChanged[0]} → ${p.nameChanged[1]}`], tone: "changed" });
+    if (p.runtimeChanged) out.push({ label: "Runtime", items: [`${p.runtimeChanged[0]} → ${p.runtimeChanged[1]}`], tone: "changed" });
+    return out;
   }
 
   if (loading) return <div className="flex justify-center py-12"><div className="w-6 h-6 border-2 border-primary-500/30 border-t-primary-500 rounded-full animate-spin" /></div>;
@@ -96,26 +133,41 @@ export default function VersioningTab({ projectId }: { projectId: string; projec
                       Diff vs v{prevSnap.version}
                     </button>
                   )}
-                  {confirmRollback === snap.version ? (
-                    <div className="flex items-center gap-1">
-                      <span className="text-xs text-warning-light">Restaurar?</span>
-                      <button onClick={() => handleRollback(snap.version)} className="px-2 py-0.5 rounded bg-warning text-black text-xs">Si</button>
-                      <button onClick={() => setConfirmRollback(null)} className="px-2 py-0.5 rounded bg-gray-700 text-gray-300 text-xs">No</button>
-                    </div>
-                  ) : (
-                    <button
-                      onClick={() => setConfirmRollback(snap.version)}
-                      className="px-2 py-1 rounded bg-warning/10 text-warning-light text-xs hover:bg-warning/20 transition-colors"
-                    >
-                      Restaurar
-                    </button>
-                  )}
+                  <button
+                    onClick={() => openRollbackPreview(snap.version)}
+                    className="px-2 py-1 rounded bg-warning/10 text-warning-light text-xs hover:bg-warning/20 transition-colors"
+                  >
+                    Restaurar
+                  </button>
                 </div>
               </div>
             );
           })}
         </div>
       )}
+
+      <PreviewConfirmModal
+        open={!!rollback}
+        title={`Rollback a snapshot v${rollback?.version ?? ""}`}
+        subtitle={
+          rollback?.preview
+            ? `Tomado el ${new Date(rollback.preview.targetTimestamp).toLocaleString("es")}. Sobrescribe el manifest actual.`
+            : rollback?.loading
+              ? "Calculando cambios..."
+              : ""
+        }
+        sections={rollback?.preview ? rollbackSections(rollback.preview) : []}
+        warning={
+          rollback?.preview && !rollback.preview.currentManifestExists
+            ? "El proyecto no tiene manifest actualmente. El rollback creara uno nuevo desde el snapshot."
+            : undefined
+        }
+        confirmLabel={`Restaurar v${rollback?.version ?? ""}`}
+        destructive
+        busy={!!rollback?.applying || !!rollback?.loading}
+        onConfirm={applyRollback}
+        onCancel={() => setRollback(null)}
+      />
 
       {diff && (
         <div className="rounded-xl bg-gray-900 border border-gray-800 p-4">

--- a/src/components/ui/PreviewConfirmModal.css
+++ b/src/components/ui/PreviewConfirmModal.css
@@ -1,0 +1,153 @@
+.dlx-pcm__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.dlx-pcm__panel {
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.875rem;
+  width: 100%;
+  max-width: 36rem;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5);
+  font-family: 'Courier New', Courier, monospace;
+  color: #e6e6f0;
+}
+
+.dlx-pcm__header {
+  padding: 1.25rem 1.5rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.dlx-pcm__title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+
+.dlx-pcm__subtitle {
+  font-size: 0.8125rem;
+  color: #9a9ab8;
+  margin: 0.25rem 0 0;
+}
+
+.dlx-pcm__body {
+  padding: 1rem 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.dlx-pcm__empty {
+  font-size: 0.875rem;
+  color: #9a9ab8;
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.dlx-pcm__section {
+  margin-bottom: 1rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: 0.5rem;
+  border-left: 3px solid;
+}
+
+.dlx-pcm__section--neutral { border-color: #60a5fa; background: rgba(96, 165, 250, 0.05); }
+.dlx-pcm__section--added { border-color: #4ade80; background: rgba(74, 222, 128, 0.05); }
+.dlx-pcm__section--removed { border-color: #f87171; background: rgba(248, 113, 113, 0.05); }
+.dlx-pcm__section--changed { border-color: #fbbf24; background: rgba(251, 191, 36, 0.05); }
+.dlx-pcm__section--warning { border-color: #fb923c; background: rgba(251, 146, 60, 0.05); }
+
+.dlx-pcm__section-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.5rem;
+  color: #c5c5e0;
+  font-weight: 600;
+}
+
+.dlx-pcm__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: #d8d8ee;
+}
+
+.dlx-pcm__list li {
+  word-break: break-word;
+}
+
+.dlx-pcm__warning {
+  margin-top: 1rem;
+  padding: 0.75rem 0.875rem;
+  background: rgba(251, 146, 60, 0.1);
+  border: 1px solid rgba(251, 146, 60, 0.3);
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  color: #ffb87a;
+}
+
+.dlx-pcm__footer {
+  padding: 0.875rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.625rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.dlx-pcm__btn {
+  padding: 0.5rem 1.125rem;
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+  border: 1px solid transparent;
+  font-family: inherit;
+}
+
+.dlx-pcm__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dlx-pcm__btn--cancel {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #c5c5e0;
+}
+
+.dlx-pcm__btn--cancel:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.dlx-pcm__btn--primary {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.dlx-pcm__btn--primary:not(:disabled):hover {
+  background: #2563eb;
+}
+
+.dlx-pcm__btn--destructive {
+  background: #dc2626;
+  color: #fff;
+}
+
+.dlx-pcm__btn--destructive:not(:disabled):hover {
+  background: #b91c1c;
+}

--- a/src/components/ui/PreviewConfirmModal.tsx
+++ b/src/components/ui/PreviewConfirmModal.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import "./PreviewConfirmModal.css";
+
+export interface PreviewSection {
+  label: string;
+  items: string[];
+  tone?: "neutral" | "added" | "removed" | "changed" | "warning";
+}
+
+interface Props {
+  open: boolean;
+  title: string;
+  subtitle?: string;
+  sections: PreviewSection[];
+  warning?: string;
+  confirmLabel?: string;
+  destructive?: boolean;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function PreviewConfirmModal({
+  open,
+  title,
+  subtitle,
+  sections,
+  warning,
+  confirmLabel = "Confirmar",
+  destructive = false,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, busy, onCancel]);
+
+  if (!open) return null;
+
+  const visibleSections = sections.filter((s) => s.items.length > 0);
+  const empty = visibleSections.length === 0;
+
+  return createPortal(
+    <div className="dlx-pcm__backdrop" onClick={() => !busy && onCancel()}>
+      <div className="dlx-pcm__panel" onClick={(e) => e.stopPropagation()}>
+        <header className="dlx-pcm__header">
+          <h3 className="dlx-pcm__title">{title}</h3>
+          {subtitle && <p className="dlx-pcm__subtitle">{subtitle}</p>}
+        </header>
+
+        <div className="dlx-pcm__body">
+          {empty && (
+            <p className="dlx-pcm__empty">
+              No hay cambios para mostrar. La accion no modificara nada.
+            </p>
+          )}
+          {visibleSections.map((s, i) => (
+            <section key={i} className={`dlx-pcm__section dlx-pcm__section--${s.tone ?? "neutral"}`}>
+              <h4 className="dlx-pcm__section-label">{s.label}</h4>
+              <ul className="dlx-pcm__list">
+                {s.items.map((item, j) => (
+                  <li key={j}>{item}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+          {warning && (
+            <div className="dlx-pcm__warning">
+              <strong>Advertencia:</strong> {warning}
+            </div>
+          )}
+        </div>
+
+        <footer className="dlx-pcm__footer">
+          <button
+            type="button"
+            className="dlx-pcm__btn dlx-pcm__btn--cancel"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className={`dlx-pcm__btn ${destructive ? "dlx-pcm__btn--destructive" : "dlx-pcm__btn--primary"}`}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? "Aplicando..." : confirmLabel}
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/ui/Toast.css
+++ b/src/components/ui/Toast.css
@@ -9,9 +9,10 @@
   font-size: 0.8125rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  max-width: 22rem;
+  max-width: 28rem;
   overflow: hidden;
   cursor: default;
+  line-height: 1.5;
 }
 
 .dlx-toast__bg {
@@ -30,6 +31,8 @@
   position: relative;
   z-index: 1;
   white-space: pre-line;
+  word-break: break-word;
+  display: block;
 }
 
 .dlx-toast__progress {

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { create } from "zustand";
+import { toErrorMessage, type UiError } from "@/lib/errors";
 import "./Toast.css";
 
 /* ── Store global ─────────────────────────── */
@@ -25,12 +26,18 @@ export const useToastStore = create<ToastStore>()((set) => ({
     set({ toast: { message, type, duration, key: Date.now() } }),
 }));
 
-/** Shorthand: toast.success("mensaje"), toast.error("mensaje"), etc. */
+/** Shorthand: toast.success("mensaje"), toast.error("mensaje" | UiError | unknown), etc.
+ *  toast.error acepta UiError estructurado y lo formatea a multilinea automaticamente. */
 export const toast = {
   success: (msg: string, duration?: number) =>
     useToastStore.getState().show(msg, "success", duration),
-  error: (msg: string, duration?: number) =>
-    useToastStore.getState().show(msg, "error", duration),
+  error: (msg: string | UiError | unknown, duration?: number) => {
+    const text = typeof msg === "string" ? msg : toErrorMessage(msg);
+    const wantsLonger = text.includes("\n");
+    useToastStore
+      .getState()
+      .show(text, "error", duration ?? (wantsLonger ? 8000 : 3000));
+  },
   warning: (msg: string, duration?: number) =>
     useToastStore.getState().show(msg, "warning", duration),
   info: (msg: string, duration?: number) =>

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,38 @@
+export interface UiError {
+  intento: string;
+  detecto: string;
+  fallo: string;
+  hacer: string;
+}
+
+export function isUiError(value: unknown): value is UiError {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.intento === "string" &&
+    typeof v.detecto === "string" &&
+    typeof v.fallo === "string" &&
+    typeof v.hacer === "string"
+  );
+}
+
+export function parseUiError(err: unknown): UiError | null {
+  if (isUiError(err)) return err;
+  return null;
+}
+
+export function formatUiError(err: UiError): string {
+  const parts = [`Intento: ${err.intento}`];
+  if (err.detecto) parts.push(`Detecto: ${err.detecto}`);
+  if (err.fallo) parts.push(`Fallo: ${err.fallo}`);
+  if (err.hacer) parts.push(`Que hacer: ${err.hacer}`);
+  return parts.join("\n");
+}
+
+export function toErrorMessage(err: unknown, fallback = "Error desconocido"): string {
+  const ui = parseUiError(err);
+  if (ui) return formatUiError(ui);
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return fallback;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -201,6 +201,21 @@ function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> 
     case "import_project":
       return Promise.resolve({ id: `mock-import-${Date.now()}`, name: "imported", path: "/tmp/imported", runtimes: [], status: "active", createdAt: new Date().toISOString(), tags: [] } as T);
 
+    case "preview_import":
+      return Promise.resolve({
+        name: "imported",
+        description: "Mock preview en navegador",
+        runtimes: [{ runtime: "node", version: "22.16.0" }],
+        tags: ["mock"],
+        templateId: null,
+        envKeys: ["DATABASE_URL", "API_KEY"],
+        hasManifest: true,
+        targetPath: (args?.targetPath as string) ?? "/tmp/imported",
+        targetExists: false,
+        targetHasFiles: false,
+        conflictWithExisting: false,
+      } as T);
+
     case "generate_vscode_workspace":
       return Promise.resolve({ filesCreated: ["proyecto.code-workspace", ".vscode/tasks.json", ".vscode/launch.json", ".vscode/extensions.json"], filesSkipped: [], warnings: [] } as T);
 
@@ -299,6 +314,21 @@ function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> 
 
     case "rollback_snapshot":
       return Promise.resolve(undefined as T);
+
+    case "preview_rollback":
+      return Promise.resolve({
+        targetVersion: (args?.version as number) ?? 1,
+        targetTimestamp: new Date().toISOString(),
+        currentManifestExists: true,
+        addedTechs: ["react"],
+        removedTechs: ["vue"],
+        addedRecipes: ["testing-vitest"],
+        removedRecipes: [],
+        profileChanged: ["production", "rapid"],
+        editorChanged: null,
+        nameChanged: null,
+        runtimeChanged: null,
+      } as T);
 
     case "take_env_snapshot":
       return Promise.resolve({ timestamp: new Date().toISOString(), runtimes: [], depsHash: "" } as T);
@@ -466,6 +496,10 @@ export async function exportProject(projectId: string): Promise<string> {
 
 export async function importProject(json: string, targetPath: string): Promise<Project> {
   return safeInvoke<Project>("import_project", { json, targetPath });
+}
+
+export async function previewImport(json: string, targetPath: string): Promise<import("@/types/portable").ImportPreview> {
+  return safeInvoke<import("@/types/portable").ImportPreview>("preview_import", { json, targetPath });
 }
 
 // --- VSCode Workspace ---
@@ -640,6 +674,10 @@ export async function diffSnapshots(projectId: string, v1: number, v2: number): 
 
 export async function rollbackSnapshot(projectId: string, version: number): Promise<void> {
   return safeInvoke<void>("rollback_snapshot", { projectId, version });
+}
+
+export async function previewRollback(projectId: string, version: number): Promise<import("@/types/versioning").RollbackPreview> {
+  return safeInvoke<import("@/types/versioning").RollbackPreview>("preview_rollback", { projectId, version });
 }
 
 // --- Env Snapshots ---

--- a/src/types/portable.ts
+++ b/src/types/portable.ts
@@ -1,0 +1,15 @@
+import type { RuntimeConfig } from "@/types/project";
+
+export interface ImportPreview {
+  name: string;
+  description: string | null;
+  runtimes: RuntimeConfig[];
+  tags: string[];
+  templateId: string | null;
+  envKeys: string[];
+  hasManifest: boolean;
+  targetPath: string;
+  targetExists: boolean;
+  targetHasFiles: boolean;
+  conflictWithExisting: boolean;
+}

--- a/src/types/versioning.ts
+++ b/src/types/versioning.ts
@@ -35,3 +35,17 @@ export interface EnvDiff {
   changedRuntimes: RuntimeChange[];
   depsChanged: boolean;
 }
+
+export interface RollbackPreview {
+  targetVersion: number;
+  targetTimestamp: string;
+  currentManifestExists: boolean;
+  addedTechs: string[];
+  removedTechs: string[];
+  addedRecipes: string[];
+  removedRecipes: string[];
+  profileChanged: [string, string] | null;
+  editorChanged: [string | null, string | null] | null;
+  nameChanged: [string, string] | null;
+  runtimeChanged: [string, string] | null;
+}


### PR DESCRIPTION
## Cambios

### fix(npm): descargar binario desde GitHub Releases en postinstall

El wrapper \`@delixon/nexenv\` dependia de 4 sub-paquetes \`@delixon/nexenv-{os}-{arch}\` que nunca se publicaron en npm. \`require.resolve\` fallaba, el \`catch {}\` silenciaba el error y nunca se copiaba el binario. Al ejecutar \`nexenv\` el wrapper intentaba un \`execFileSync\` sobre un \`.exe\` inexistente y terminaba con ENOENT sin output.

El nuevo \`postinstall.js\` descarga el binario desde el GitHub Release de la version indicada en \`package.json\`, siguiendo redirects. Errores con URL intentada y fallback a descarga manual. Quitadas las \`optionalDependencies\`.

Alineado con el wrapper pip.

## Test

\`\`\`bash
npm install -g @delixon/nexenv   # tras publicar 1.0.0
nexenv --version                  # -> Nexenv 1.0.0
\`\`\`

Closes #115