### PR TITLE
chore: bump to 1.0.0-beta.1

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "0.0.1",
+  "version": "1.0.0-beta.1",
   "description": "Workspace manager for developers — GUI + CLI",
   "license": "FSL-1.1-ALv2",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexenv",
-  "version": "0.1.0-beta.1",
+  "version": "1.0.0-beta.1",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/pip/cli/nexenv/cli.py
+++ b/pip/cli/nexenv/cli.py
@@ -7,7 +7,7 @@ import sys
 import urllib.request
 from pathlib import Path
 
-__version__ = "0.0.1"
+__version__ = "1.0.0-beta.1"
 
 PLATFORM_MAP = {
     ("Windows", "AMD64"): "nexenv-cli-win32-x64.exe",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "0.0.1"
+version = "1.0.0b1"
 description = "Workspace manager for developers"
 readme = "README.md"
 license = {text = "FSL-1.1-ALv2"}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2242,7 +2242,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nexenv"
-version = "0.1.0-beta.1"
+version = "1.0.0-beta.1"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexenv"
-version = "0.1.0-beta.1"
+version = "1.0.0-beta.1"
 description = "Gestor de workspaces para desarrolladores"
 authors = ["delirrestevez"]
 license = "FSL-1.1-ALv2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Nexenv",
-  "version": "0.1.0",
+  "version": "1.0.0-beta.1",
   "identifier": "dev.delixon.nexenv",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Sincroniza los 6 manifests de version para el primer release beta del ciclo v1.0.0.