### PR TITLE
fix(tauri): desactivar createUpdaterArtifacts para v1.0.0-beta.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
       "icons/icon.ico",
       "icons/icon.png"
     ],
-    "createUpdaterArtifacts": true
+    "createUpdaterArtifacts": false
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
El bundler fallaba al firmar artifacts con signing-key placeholder. Deshabilita createUpdaterArtifacts para que el CI genere installers sin firma. Activacion del updater es issue delixon-labs/nexenv-core#32 (post-v1.0.0).