### PR TITLE
fix(ci): renombrar CLI binaries y compilar macOS arm64+x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Build CLI binary
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
+      # Rename: los wrappers npm/pip esperan nexenv-cli-{platform}-{arch}[.exe]
+      - name: Rename CLI binary
+        shell: bash
+        run: cp src-tauri/target/release/nexenv-cli.exe src-tauri/target/release/nexenv-cli-win32-x64.exe
+
       - name: Upload release assets
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
@@ -65,7 +70,7 @@ jobs:
           files: |
             src-tauri/target/release/bundle/msi/*.msi
             src-tauri/target/release/bundle/nsis/*.exe
-            src-tauri/target/release/nexenv-cli.exe
+            src-tauri/target/release/nexenv-cli-win32-x64.exe
 
   release-linux:
     runs-on: ubuntu-latest
@@ -108,6 +113,9 @@ jobs:
       - name: Build CLI binary
         run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
 
+      - name: Rename CLI binary
+        run: cp src-tauri/target/release/nexenv-cli src-tauri/target/release/nexenv-cli-linux-x64
+
       - name: Upload release assets
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
@@ -115,12 +123,20 @@ jobs:
           files: |
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
-            src-tauri/target/release/nexenv-cli
+            src-tauri/target/release/nexenv-cli-linux-x64
 
   release-macos:
     runs-on: macos-latest
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rust_target: aarch64-apple-darwin
+            suffix: arm64
+          - rust_target: x86_64-apple-darwin
+            suffix: x64
 
     steps:
       - name: Checkout
@@ -136,27 +152,32 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+          targets: ${{ matrix.rust_target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./src-tauri -> target"
+          key: "${{ matrix.rust_target }}"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build Tauri installer
-        run: npm run tauri build
+        run: npm run tauri build -- --target ${{ matrix.rust_target }}
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
 
       - name: Build CLI binary
-        run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release
+        run: cargo build --manifest-path src-tauri/Cargo.toml --bin nexenv-cli --no-default-features --release --target ${{ matrix.rust_target }}
+
+      - name: Rename CLI binary
+        run: cp src-tauri/target/${{ matrix.rust_target }}/release/nexenv-cli src-tauri/target/${{ matrix.rust_target }}/release/nexenv-cli-darwin-${{ matrix.suffix }}
 
       - name: Upload release assets
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           draft: true
           files: |
-            src-tauri/target/release/bundle/dmg/*.dmg
-            src-tauri/target/release/nexenv-cli
+            src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg/*.dmg
+            src-tauri/target/${{ matrix.rust_target }}/release/nexenv-cli-darwin-${{ matrix.suffix }}


### PR DESCRIPTION
Arregla el 404 que tendrian los usuarios al hacer npm install / pip install: los wrappers buscan nexenv-cli-{platform}-{arch} y el workflow subia nombres genericos. Ademas matrix macOS para generar DMG y CLI tanto Apple Silicon como Intel.