### PR TITLE
chore: bump 1.0.0-beta.2 + fix CLI version + canonicalize path

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Workspace manager for developers — GUI + CLI",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexenv",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/pip/cli/nexenv/cli.py
+++ b/pip/cli/nexenv/cli.py
@@ -7,7 +7,7 @@ import sys
 import urllib.request
 from pathlib import Path
 
-__version__ = "1.0.0-beta.1"
+__version__ = "1.0.0-beta.2"
 
 PLATFORM_MAP = {
     ("Windows", "AMD64"): "nexenv-cli-win32-x64.exe",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.0.0b1"
+version = "1.0.0b2"
 description = "Workspace manager for developers"
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2242,7 +2242,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nexenv"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexenv"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 description = "Gestor de workspaces para desarrolladores"
 authors = ["delirrestevez"]
 license = "FSL-1.1-ALv2"

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -6,7 +6,7 @@ use nexenv_lib::core::{
 };
 
 #[derive(Parser)]
-#[command(name = "nexenv", version = "1.0.0", about = "Workspace manager for developers")]
+#[command(name = "nexenv", version = env!("CARGO_PKG_VERSION"), about = "Workspace manager for developers")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/src-tauri/src/core/templates/mod.rs
+++ b/src-tauri/src/core/templates/mod.rs
@@ -56,6 +56,16 @@ pub fn create_from_template(
         std::fs::write(&file_path, content)?;
     }
 
+    // Canonicalizar el path para guardarlo absoluto en la BD. Evita que paths
+    // relativos como "." colisionen con la constraint UNIQUE de projects.path
+    // cuando el usuario crea varios proyectos en cwd distintos pasando ".".
+    let canonical_path = std::fs::canonicalize(base)
+        .map(|p| p.to_string_lossy().into_owned())
+        .or_else(|_| -> Result<String, NexenvError> {
+            let cwd = std::env::current_dir().map_err(NexenvError::Io)?;
+            Ok(cwd.join(project_path).to_string_lossy().into_owned())
+        })?;
+
     let runtimes: Vec<RuntimeConfig> = template
         .runtimes
         .iter()
@@ -71,7 +81,7 @@ pub fn create_from_template(
     let project = Project {
         id: uuid::Uuid::new_v4().to_string(),
         name: project_name.to_string(),
-        path: project_path.to_string(),
+        path: canonical_path,
         description: Some(format!("Creado desde plantilla: {}", template.name)),
         runtimes,
         status: ProjectStatus::Active,

--- a/src-tauri/src/core/workspace/scaffold.rs
+++ b/src-tauri/src/core/workspace/scaffold.rs
@@ -529,10 +529,19 @@ pub fn register_scaffolded_project(
         })
         .collect();
 
+    // Canonicalizar el path para guardarlo absoluto. Evita que paths relativos
+    // como "." colisionen con la constraint UNIQUE de projects.path.
+    let canonical_path = std::fs::canonicalize(&config.path)
+        .map(|p| p.to_string_lossy().into_owned())
+        .or_else(|_| -> Result<String, NexenvError> {
+            let cwd = std::env::current_dir().map_err(NexenvError::Io)?;
+            Ok(cwd.join(&config.path).to_string_lossy().into_owned())
+        })?;
+
     let project = Project {
         id: uuid::Uuid::new_v4().to_string(),
         name: config.name.clone(),
-        path: config.path.clone(),
+        path: canonical_path,
         description: None,
         runtimes,
         status: ProjectStatus::Active,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Nexenv",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "identifier": "dev.delixon.nexenv",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Arregla 2 bugs detectados en el smoke de v1.0.0-beta.1: (1) CLI --version hardcoded 1.0.0, (2) UNIQUE constraint al registrar proyecto con --path '.'. Tests 175/175.