### PR TITLE
fix(settings): usar fetchProjects en Mantenimiento

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -29,7 +29,7 @@ export default function Settings() {
   const [orphansLoading, setOrphansLoading] = useState(false);
   const [orphansCleaning, setOrphansCleaning] = useState(false);
   const [orphansModalOpen, setOrphansModalOpen] = useState(false);
-  const reloadProjects = useProjectsStore((s) => s.loadProjects);
+  const reloadProjects = useProjectsStore((s) => s.fetchProjects);
 
   useEffect(() => {
     if (!isLoaded) loadConfig();


### PR DESCRIPTION
Corrige error de TypeScript que rompia el build de CI en los 4 OS (tsc se ejecuta antes de tauri build).

El store de proyectos expone fetchProjects, no loadProjects.