### PR TITLE
fix(cli): rutas sin prefijo \?\ en CLI

### DIFF
--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -320,7 +320,7 @@ fn cmd_list() -> Result<(), String> {
             p.name,
             status,
             runtimes.join(", "),
-            p.path.dimmed()
+            nexenv_lib::core::utils::fs::pretty_path(&p.path).dimmed()
         );
     }
 
@@ -361,7 +361,7 @@ fn cmd_unlink(name: &str) -> Result<(), String> {
         "{} {} desvinculado (los archivos en {} no se han borrado)",
         "Ok".green().bold(),
         project.name.bold(),
-        project.path
+        nexenv_lib::core::utils::fs::pretty_path(&project.path)
     );
 
     Ok(())
@@ -377,7 +377,7 @@ fn cmd_create(name: &str, path: &str, template: Option<&str>) -> Result<(), Stri
         );
         let project = templates::create_from_template(tpl_id, path, name)
             .map_err(|e| e.to_string())?;
-        println!("{} Proyecto creado: {}", "ok".green().bold(), project.path);
+        println!("{} Proyecto creado: {}", "ok".green().bold(), nexenv_lib::core::utils::fs::pretty_path(&project.path));
     } else {
         println!(
             "{} proyecto '{}'...",
@@ -582,7 +582,7 @@ fn cmd_import(file: &str, path: &str) -> Result<(), String> {
         "{} Proyecto '{}' importado en {}",
         "ok".green().bold(),
         project.name,
-        project.path
+        nexenv_lib::core::utils::fs::pretty_path(&project.path)
     );
     Ok(())
 }
@@ -651,7 +651,7 @@ fn cmd_manifest(project_name: &str) -> Result<(), String> {
             println!("{}", "No se encontro manifest. Generando...".yellow());
             let m = manifest::generate_manifest_from_project(project);
             manifest::save_manifest(&project.path, &m).map_err(|e| e.to_string())?;
-            println!("{} Manifest generado en {}/.nexenv/manifest.yaml", "ok".green().bold(), project.path);
+            println!("{} Manifest generado en {}/.nexenv/manifest.yaml", "ok".green().bold(), nexenv_lib::core::utils::fs::pretty_path(&project.path));
         }
     }
     Ok(())

--- a/src-tauri/src/core/utils/fs.rs
+++ b/src-tauri/src/core/utils/fs.rs
@@ -5,6 +5,18 @@ pub fn ensure_dir(path: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(path)
 }
 
+/// Quita el prefijo `\\?\` de Windows extended-length paths para mostrar al usuario.
+/// `std::fs::canonicalize` lo agrega cuando la ruta excede MAX_PATH.
+pub fn pretty_path(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{}", rest);
+    }
+    if let Some(rest) = path.strip_prefix(r"\\?\") {
+        return rest.to_string();
+    }
+    path.to_string()
+}
+
 /// Asegura que ciertas entradas existan en el .gitignore del proyecto.
 /// Si el archivo no existe, lo crea. Si ya contiene la entrada, la ignora.
 pub fn ensure_gitignore_entries(project_path: &Path, entries: &[&str]) -> std::io::Result<()> {


### PR DESCRIPTION
Aplica pretty_path en mensajes visibles del CLI: list, create, import, unlink, manifest.