### PR TITLE
docs(licencia): clarificar source-available + compliance files (SECURITY, CONTRIBUTING, COC)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Code of Conduct
+
+## Our commitment
+
+We — the maintainers and contributors of Nexenv — are committed to providing a harassment-free, respectful and constructive environment for everyone, regardless of experience level, gender identity, sexual orientation, disability, personal appearance, body size, race, age, religion, or nationality.
+
+## Expected behavior
+
+- Be respectful. Disagree without being hostile.
+- Focus on what is best for the project.
+- Give and receive constructive feedback gracefully.
+- Respect differing viewpoints and experiences.
+- Acknowledge mistakes, apologize, and learn.
+
+## Unacceptable behavior
+
+- Harassment, insults, personal attacks, or derogatory comments.
+- Public or private harassment of any form.
+- Publishing others' private information without explicit permission.
+- Unwelcome sexual attention or advances.
+- Sustained disruption of discussions, talks, or community interactions.
+- Any conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Scope
+
+This Code of Conduct applies to all project spaces — GitHub issues, pull requests, discussions, commits, documentation, and any other space managed by the Delixon Labs team. It also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at `conduct@delixon.dev`. All complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Consequences
+
+Maintainers may take any action they deem appropriate, including:
+
+1. **Warning** — a private message explaining the issue.
+2. **Temporary removal** from discussions or contributions for a period.
+3. **Permanent ban** from the project and its spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.
+
+For questions: `conduct@delixon.dev`.
+
+---
+
+*Last updated: 2026-04-21*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing to Nexenv
+
+Thanks for your interest in contributing to Nexenv.
+
+Nexenv is a product of [Delixon Labs](https://delixon.dev), the developer tools division of [XPlus Technologies LLC](https://xplustechnologies.com). It is licensed under [FSL-1.1-ALv2](LICENSE) — source-available, not open source.
+
+Before contributing, please read this document in full.
+
+---
+
+## Before you start
+
+### License and contributions
+
+Nexenv is **source-available**, not open source. By contributing code, documentation, or other materials to this project, you agree that your contribution is licensed under the same terms as the rest of the project (FSL-1.1-ALv2 with conversion to Apache 2.0 two years after each version's release).
+
+For non-trivial contributions, we may ask you to sign a Contributor License Agreement (CLA) before merging. This is a lightweight agreement that confirms you have the right to contribute the code and grants us the necessary license to include it. We'll send you the CLA when your PR reaches that point.
+
+### Code of conduct
+
+All contributors are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md). Be respectful, constructive, and focused on the work.
+
+---
+
+## What kind of contributions are welcome
+
+### ✅ Welcome
+
+- **Bug reports** with clear reproduction steps
+- **Bug fixes** with tests
+- **Documentation improvements** (README, docs/, inline comments)
+- **Typo fixes** and small polish PRs
+- **New templates** (add an entry under `src-tauri/src/core/templates/`)
+- **New recipes** (add under `src-tauri/src/core/recipes/`)
+- **New technology entries** in the catalog (`src-tauri/src/core/catalog/technologies/*.yaml`)
+- **Translations** of the UI
+- **Performance improvements** with benchmarks
+- **Cross-platform bug fixes** (Windows/macOS/Linux specific issues)
+
+### ⚠️ Discuss first (open an issue)
+
+- **New commands** or major CLI surface changes
+- **Breaking changes** to the manifest format
+- **New core features** not already on the roadmap
+- **Large refactors** of the Rust core or React frontend
+- **Changes to the scan/detect logic** that affect existing projects
+- **Additions to the CI/release pipeline**
+
+### ❌ Not welcome
+
+- Contributions that modify the license or its enforcement
+- Changes that remove or weaken local-first guarantees
+- Telemetry or tracking added without explicit opt-in design
+- Commercial-competitor adaptations (prohibited by license)
+- Security vulnerability reports in PRs (see [SECURITY.md](SECURITY.md))
+
+---
+
+## How to contribute
+
+### 1. Find or create an issue
+
+- Check [existing issues](https://github.com/delixon-labs/delixon-nexenv/issues).
+- For small fixes (typos, clear bugs), feel free to open a PR directly.
+- For larger changes, **open an issue first** to discuss the approach. This saves you time and helps us align.
+
+### 2. Fork and branch
+
+```bash
+# Fork via the GitHub UI, then:
+git clone https://github.com/YOUR-USERNAME/delixon-nexenv.git
+cd delixon-nexenv
+git checkout -b fix/description-of-change
+```
+
+### 3. Set up your development environment
+
+See the [README Development section](README.md#development) for requirements and setup.
+
+Minimum versions:
+- Rust 1.77+
+- Node.js 22+
+- npm 10+
+
+### 4. Make your changes
+
+- Follow existing code style (rustfmt for Rust, Prettier for TS/TSX).
+- Add tests for new functionality.
+- Update documentation if user-facing behavior changes.
+- Keep commits focused — one logical change per commit.
+
+### 5. Test
+
+```bash
+# Rust core
+cd src-tauri && cargo test
+
+# Frontend
+npm run test
+npm run lint
+
+# Build
+npm run tauri build
+```
+
+### 6. Submit a pull request
+
+- Target the `develop` branch, not `main`.
+- Write a clear title and description.
+- Link the issue if one exists.
+- Explain the why, not just the what.
+- Include screenshots or GIFs for UI changes.
+
+### 7. Review process
+
+- A maintainer will review within ~7 days for most PRs.
+- We may ask for changes or discuss alternative approaches.
+- Once approved, a maintainer will merge and include in the next release.
+
+---
+
+## Branching and releases
+
+Nexenv uses a three-branch model:
+
+```
+feature/* or fix/*  →  desarrollo  →  develop  →  main
+```
+
+- `desarrollo`: day-to-day work, fast-moving.
+- `develop`: integration branch before release.
+- `main`: tracks the latest stable release (tagged).
+
+Releases are cut by maintainers. Contributors should never push directly to `develop` or `main`.
+
+---
+
+## Reporting bugs
+
+Before opening an issue:
+1. Search existing issues.
+2. Reproduce with the latest version (`nexenv --version` to check).
+3. Collect: OS + version, Nexenv version, full error output, minimal reproduction steps.
+
+Issue templates will guide you through this.
+
+---
+
+## Requesting features
+
+Open an issue with:
+- The problem you're trying to solve (the *why*).
+- How you currently work around it.
+- Your proposed solution (if any).
+- Why this fits Nexenv's scope ("per-project development environment manager").
+
+Features that don't fit Nexenv's scope will be declined respectfully.
+
+---
+
+## What not to do
+
+- Don't submit PRs for unrelated changes (one topic per PR).
+- Don't change the license or remove copyright notices.
+- Don't add dependencies without discussion (we keep the dep graph tight).
+- Don't submit AI-generated code without review (mention it in the PR description).
+- Don't report security issues publicly (see [SECURITY.md](SECURITY.md)).
+
+---
+
+## Getting help
+
+- **Questions about using Nexenv**: [GitHub Discussions](https://github.com/delixon-labs/delixon-nexenv/discussions)
+- **Bug reports**: [GitHub Issues](https://github.com/delixon-labs/delixon-nexenv/issues)
+- **Security issues**: see [SECURITY.md](SECURITY.md)
+- **Licensing questions**: see [LICENSE-FAQ.md](LICENSE-FAQ.md) or email `hello@delixon.dev`
+
+---
+
+## Recognition
+
+Contributors are credited in release notes. For significant contributions, you'll be listed in a CONTRIBUTORS.md (coming).
+
+Thank you for helping make Nexenv better.

--- a/LICENSE-FAQ.md
+++ b/LICENSE-FAQ.md
@@ -38,7 +38,28 @@ No. Internal use is always permitted.
 No. That would be a Competing Use under the license terms.
 
 **When does it become Apache 2.0?**
-Two years after each version's release date. After that date, you may use that version under the full terms of the Apache License 2.0, including commercial use.
+Two years after each version's release date. After that date, you may use that version under the full terms of the Apache License 2.0, including commercial use. Example: Nexenv v1.0.0 released 2026-04-21 becomes Apache 2.0 on 2028-04-21 — automatically, without any action from us.
+
+**Is Nexenv open source?**
+No, not during the first two years of each release. Nexenv is *source-available*: the source code is viewable and usable with the restrictions listed above. After two years per version, each release becomes open source under Apache 2.0 automatically.
+
+**Why not Apache 2.0 from day one?**
+Building Nexenv takes resources. FSL lets us share the code with the community while protecting the project during its growth phase. After two years, every version becomes open source regardless of what we do — it's a commitment coded into the license, not a promise.
+
+**Can I audit the code before using Nexenv?**
+Yes. The source is publicly viewable (see the repository). For enterprise compliance requirements (SOC2, HIPAA, etc.), we also offer formal code audits under NDA. Contact: hello@delixon.dev.
+
+**How do I know Nexenv isn't sending my data somewhere?**
+Nexenv is local-first by design. All data lives in SQLite on your machine (`~/.nexenv/`). There is no telemetry by default, no required account, no cloud component in the core product. You can verify this with standard tools (Wireshark, Little Snitch, lsof).
+
+**What happens if Delixon disappears?**
+Three things protect you:
+1. Your data lives on your machine. Manifests are plain YAML — readable and portable without Nexenv.
+2. The binary you have already downloaded keeps working.
+3. Every version converts to Apache 2.0 after two years — v1.0.0 becomes fully open source in 2028 regardless of what happens to us.
+
+**Can I contribute?**
+Yes. For bug fixes, feature suggestions and small improvements, PRs and issues are welcome in the public repository. For larger contributions touching the core, we may require a Contributor License Agreement (CLA). See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Nexenv</h1>
 
 <p align="center">
-  <strong>Workspace manager for developers.</strong><br>
-  Stop configuring. Start building.
+  <strong>Per-project development environment manager.</strong><br>
+  Detects stack, isolates variables, opens projects ready to work.
 </p>
 
 <p align="center">
@@ -18,9 +18,9 @@
 
 ---
 
-Nexenv is a cross-platform desktop application that manages development environments per project — fully isolated, fully local, fully private.
+Nexenv is a per-project development environment manager for Windows, macOS and Linux. Each project declares a manifest (`./.nexenv/manifest.yaml`) with its runtime version, env vars, services (Docker), health checks and editor. One command activates everything and opens the project ready to work.
 
-One click. Project open. Environment ready.
+**Source-available** under [FSL-1.1-ALv2](LICENSE) — not open source yet. Each version converts to Apache 2.0 two years after release.
 
 ## Features
 
@@ -85,10 +85,16 @@ Output: `src-tauri/target/release/bundle/`
 
 ## License
 
-Source-available under [FSL-1.1-ALv2](LICENSE). Each version converts to Apache 2.0 two years after release. See [LICENSE-FAQ.md](LICENSE-FAQ.md) for details.
+**Nexenv is source-available, not open source.**
 
+Licensed under [FSL-1.1-ALv2](LICENSE) — the Functional Source License with Apache 2.0 Future License. In plain English:
 
-You can use, study, modify and redistribute the code for any purpose **except** building a competing commercial product or service.
+- ✅ Use Nexenv for free — personal, commercial, enterprise
+- ✅ Read, study, modify and redistribute the code
+- ✅ Each version auto-converts to Apache 2.0 **two years** after its release (v1.0.0 → Apache 2.0 on 2028-04-21)
+- ❌ Don't build a commercial product or service that competes with Nexenv
+
+See [LICENSE-FAQ.md](LICENSE-FAQ.md) for the full FAQ, including enterprise use, private forks, and why we chose this model.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Supported versions
+
+We provide security updates for the latest stable release of Nexenv.
+
+| Version | Supported |
+|---------|-----------|
+| 1.0.x   | ✅ Yes    |
+| < 1.0.0 | ❌ No     |
+
+## Reporting a vulnerability
+
+If you find a security vulnerability in Nexenv, please **do not open a public GitHub issue**.
+
+Instead, report it privately via one of the following channels:
+
+- **Email:** `security@delixon.dev`
+- **GitHub Security Advisory:** [Report privately](https://github.com/delixon-labs/delixon-nexenv/security/advisories/new)
+
+### What to include
+
+Please include as much of the following as possible:
+
+- A clear description of the vulnerability
+- Steps to reproduce (proof of concept if available)
+- The version of Nexenv affected (`nexenv --version`)
+- The operating system and version
+- The potential impact (e.g. "reads env vars of other projects", "executes arbitrary code")
+- Whether you have already disclosed this to anyone else
+
+### What happens next
+
+- We will acknowledge receipt within **72 hours**.
+- We will investigate and assess severity within **7 days**.
+- We will keep you updated on progress toward a fix.
+- Once a fix is ready, we will coordinate disclosure with you.
+- You will be credited in the release notes (unless you prefer to remain anonymous).
+
+## Scope
+
+The following are considered in-scope for security reports:
+
+- Arbitrary code execution via Nexenv
+- Reading files outside the user's project directories
+- Leaking environment variables across projects
+- Tampering with the manifest format to cause unintended behavior
+- Privilege escalation
+- Memory safety bugs in the Rust core
+- Supply-chain integrity of binaries and packages distributed via npm/PyPI
+
+The following are **out of scope**:
+
+- Vulnerabilities in third-party dependencies (please report them upstream; we monitor advisories and update)
+- Issues that require local physical access to an unlocked machine
+- Social engineering or phishing
+
+## Security practices
+
+Nexenv is designed with these principles:
+
+- **Local-first**: no data leaves your machine by default.
+- **No telemetry by default**: any opt-in analytics would be clearly disclosed.
+- **Isolated storage**: project data in SQLite local (`~/.nexenv/`).
+- **Cross-platform binaries**: built in CI with reproducible pipelines.
+- **Dependency updates**: Dependabot monitors deps in CI.
+
+## Disclosure timeline
+
+We aim for **90 days** from report to public disclosure, with flexibility depending on severity and complexity.
+
+---
+
+*Last updated: 2026-04-21*

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -1,8 +1,8 @@
 # @delixon/nexenv
 
-Workspace manager for developers. GUI + CLI.
+Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI.
 
-Stop configuring. Start building.
+Source-available under [FSL-1.1-ALv2](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE) — not open source. Each version converts to Apache 2.0 two years after release.
 
 ## Install
 
@@ -10,24 +10,25 @@ Stop configuring. Start building.
 npm install -g @delixon/nexenv
 ```
 
+The CLI downloads the native binary for your platform (Windows/macOS/Linux, x64 and arm64) on first install.
+
 ## Usage
 
 ```bash
 nexenv --version
 nexenv --help
+nexenv shell          # interactive REPL
+nexenv list           # list registered projects
+nexenv doctor         # system health check
 ```
 
-## Enterprise
-
-```bash
-nexenv license activate YOUR-KEY
-```
+See the full [CLI Reference](https://github.com/delixon-labs/delixon-nexenv/blob/main/docs/cli/CLI_REFERENCE.md) for all commands.
 
 ## Links
 
 - Website: https://delixon.dev/nexenv
 - GitHub: https://github.com/delixon-labs/delixon-nexenv
-- License: [FSL-1.1-ALv2](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE)
+- License: [FSL-1.1-ALv2](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE) · [FAQ](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE-FAQ.md)
 
 ---
 

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@delixon/nexenv",
   "version": "1.0.0",
-  "description": "Workspace manager for developers — GUI + CLI",
+  "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",
   "repository": {
@@ -13,9 +13,13 @@
     "nexenv",
     "cli",
     "devtools",
-    "project-management",
     "developer-tools",
-    "workspace-manager"
+    "environment-manager",
+    "per-project-environment",
+    "stack-detection",
+    "local-first",
+    "tauri",
+    "rust"
   ],
   "bin": {
     "nexenv": "bin/nexenv"

--- a/pip/cli/README.md
+++ b/pip/cli/README.md
@@ -1,8 +1,8 @@
 # nexenv
 
-Workspace manager for developers.
+Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work.
 
-Stop configuring. Start building.
+Source-available under [FSL-1.1-ALv2](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE) — not open source. Each version converts to Apache 2.0 two years after release.
 
 ## Install
 
@@ -10,18 +10,25 @@ Stop configuring. Start building.
 pip install nexenv
 ```
 
+The CLI downloads the native binary for your platform (Windows/macOS/Linux, x64 and arm64) on first run.
+
 ## Usage
 
 ```bash
 nexenv --version
 nexenv --help
+nexenv shell          # interactive REPL
+nexenv list           # list registered projects
+nexenv doctor         # system health check
 ```
+
+See the full [CLI Reference](https://github.com/delixon-labs/delixon-nexenv/blob/main/docs/cli/CLI_REFERENCE.md) for all commands.
 
 ## Links
 
 - Website: https://delixon.dev/nexenv
 - GitHub: https://github.com/delixon-labs/delixon-nexenv
-- License: [FSL-1.1-ALv2](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE)
+- License: [FSL-1.1-ALv2](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE) · [FAQ](https://github.com/delixon-labs/delixon-nexenv/blob/main/LICENSE-FAQ.md)
 
 ---
 

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nexenv"
 version = "1.0.0"
-description = "Workspace manager for developers"
+description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"
 license-files = ["LICENSE"]
@@ -13,9 +13,9 @@ requires-python = ">=3.9"
 authors = [
     {name = "Delixon Labs", email = "hello@delixon.dev"}
 ]
-keywords = ["nexenv", "developer-tools", "workspace-manager", "devtools"]
+keywords = ["nexenv", "developer-tools", "devtools", "environment-manager", "per-project-environment", "stack-detection", "local-first"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Clarifica que Nexenv es **source-available** (no open source) en todos los surfaces publicos: README, npm, pip, FAQ.

Agrega compliance files estandar (SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md) y corrige inconsistencias:

- pip/cli/pyproject.toml: Development Status Alpha -> Production/Stable (producto es 1.0.0)
- npm/cli: description unificada, keywords correctas, quitada seccion Enterprise sin contexto
- LICENSE-FAQ.md: +8 preguntas nuevas (core privado, auditoria, disappearance, contribuir)

No hay cambios de codigo, solo documentacion y metadata.

Doc interno de referencia: nexenv.docs/estrategia-publico-privado-licencia.md