### PR TITLE
ci(publish): add pip-publish workflow for PyPI wrapper

### DIFF
--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -1,0 +1,56 @@
+name: Publish pip
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.0.1)"
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Update version in pyproject.toml
+        working-directory: pip/cli
+        run: |
+          python - <<'PY'
+          import pathlib, re, sys
+          p = pathlib.Path("pyproject.toml")
+          text = p.read_text(encoding="utf-8")
+          new = re.sub(
+              r'^(version\s*=\s*)"[^"]*"',
+              r'\1"${{ github.event.inputs.version }}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if new == text:
+              sys.exit("version field not found in pyproject.toml")
+          p.write_text(new, encoding="utf-8")
+          PY
+
+      - name: Build sdist and wheel
+        working-directory: pip/cli
+        run: python -m build
+
+      - name: Publish nexenv
+        working-directory: pip/cli
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python -m twine upload dist/*


### PR DESCRIPTION
Release a main del PR #148. Añade el workflow pip-publish.yml (análogo a npm-publish.yml) para publicar el wrapper pip desde este repo usando secrets.PYPI_TOKEN. Sin cambios en codigo del usuario.