### PR TITLE
ci: rename ramas a local/dev/main + ignore .delidocs/

### DIFF
--- a/.github/workflows/enforce-branch-flow.yml
+++ b/.github/workflows/enforce-branch-flow.yml
@@ -1,9 +1,9 @@
 name: Enforce branch flow
 
-# Flow: desarrollo → develop (PR) → main (PR)
+# Flow: local -> dev (PR) -> main (PR)
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -13,24 +13,24 @@ jobs:
     name: Verify branch flow
     runs-on: ubuntu-latest
     steps:
-      - name: PRs to main only from develop
+      - name: PRs to main only from dev
         if: github.base_ref == 'main'
         run: |
-          if [ "${{ github.head_ref }}" != "develop" ]; then
-            echo "ERROR: PRs to main must come ONLY from 'develop'."
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "ERROR: PRs to main must come ONLY from 'dev'."
             echo "Source branch: ${{ github.head_ref }}"
-            echo "Correct flow: desarrollo -> develop (PR) -> main (PR)"
+            echo "Correct flow: local -> dev (PR) -> main (PR)"
             exit 1
           fi
-          echo "OK: PR to main comes from develop."
+          echo "OK: PR to main comes from dev."
 
-      - name: PRs to develop only from desarrollo
-        if: github.base_ref == 'develop'
+      - name: PRs to dev only from local
+        if: github.base_ref == 'dev'
         run: |
-          if [ "${{ github.head_ref }}" != "desarrollo" ]; then
-            echo "ERROR: PRs to develop must come ONLY from 'desarrollo'."
+          if [ "${{ github.head_ref }}" != "local" ]; then
+            echo "ERROR: PRs to dev must come ONLY from 'local'."
             echo "Source branch: ${{ github.head_ref }}"
-            echo "Correct flow: desarrollo -> develop (PR) -> main (PR)"
+            echo "Correct flow: local -> dev (PR) -> main (PR)"
             exit 1
           fi
-          echo "OK: PR to develop comes from desarrollo."
+          echo "OK: PR to dev comes from local."

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ coverage/
 
 # Python build artifacts
 *.egg-info/
+
+# Documentacion personal del owner (planes, flujos internos)
+.delidocs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ All contributors are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md
    ```
 3. **Make your changes** in `npm/cli/`, `pip/cli/`, or the root documentation files.
 4. **Test the wrappers** as appropriate (install locally, run `nexenv --version`, etc.).
-5. **Open a PR against the `develop` branch** with a clear title and description.
+5. **Open a PR against the `dev` branch** with a clear title and description.
 
 ### Contributing to the core (private repository)
 
@@ -107,14 +107,14 @@ For small bug fixes and suggestions, opening an issue here is always the fastest
 The public repository uses a three-branch model:
 
 ```
-feature/* or fix/*  →  desarrollo  →  develop  →  main
+feature/* or fix/*  →  local  →  dev  →  main
 ```
 
-- `desarrollo`: day-to-day work, fast-moving.
-- `develop`: integration branch before release.
+- `local`: day-to-day work, fast-moving.
+- `dev`: integration branch before release.
 - `main`: tracks the latest stable release (tagged).
 
-Contributors should open PRs against `develop`. Never push directly to `develop` or `main`.
+Contributors should open PRs against `dev`. Direct pushes to `main`, `dev` and `local` are blocked by branch protection (including for maintainers — `enforce_admins: true`). Merging to `main` is restricted to repository owners.
 
 Releases are cut by maintainers from the private repository. The release workflow builds the binaries in `nexenv-core` and publishes them as assets on a release in this public repository.
 


### PR DESCRIPTION
## Cambios

- `enforce-branch-flow.yml`: triggers `[main, develop]` → `[main, dev]`; lógica actualizada para validar flujo `local → dev (PR) → main (PR)` con los nombres nuevos.
- `.gitignore`: añade `.delidocs/` para uniformar con `nexenv-core` y `delixon-platform`.

## Contexto

Rename de ramas ya aplicado en remoto vía API antes de este PR:
- `desarrollo` → `local`
- `develop` → `dev`
- `main` se mantiene

## Test plan

- [ ] enforce-branch-flow verde (valida que el PR viene de `local` a `dev`)