### PR TITLE
ci(security): environment production + PRs externos a dev

### DIFF
--- a/.github/workflows/enforce-branch-flow.yml
+++ b/.github/workflows/enforce-branch-flow.yml
@@ -1,6 +1,7 @@
 name: Enforce branch flow
 
-# Flow: local -> dev (PR) -> main (PR)
+# Flow interno: local -> dev (PR) -> main (PR)
+# Externos: fork -> PR a dev (cualquier rama del fork) -> dev -> main (por mantenedor)
 on:
   pull_request:
     branches: [main, dev]
@@ -24,13 +25,9 @@ jobs:
           fi
           echo "OK: PR to main comes from dev."
 
-      - name: PRs to dev only from local
+      - name: PRs to dev are welcome from any branch
         if: github.base_ref == 'dev'
         run: |
-          if [ "${{ github.head_ref }}" != "local" ]; then
-            echo "ERROR: PRs to dev must come ONLY from 'local'."
-            echo "Source branch: ${{ github.head_ref }}"
-            echo "Correct flow: local -> dev (PR) -> main (PR)"
-            exit 1
-          fi
-          echo "OK: PR to dev comes from local."
+          echo "OK: PR to dev accepted from '${{ github.head_ref }}'."
+          echo "Contributors (incluidos forks externos) pueden abrir PRs a dev."
+          echo "Los mantenedores revisan y deciden que se mergea."

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
 

--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
 


### PR DESCRIPTION
## Cambios

### Environment `production` para publish workflows

`npm-publish.yml` y `pip-publish.yml` ahora usan `environment: production` con:
- Required reviewers: `rrestevez-dell`, `mundowise`
- Deployment branch policy: solo `main`

Cualquier actor con `write` puede disparar el workflow pero el job queda pausado hasta aprobación de un reviewer. Protege contra triggers no autorizados.

### `enforce-branch-flow.yml` más abierto en dev

- PRs a `main` → solo desde `dev` (sin cambios).
- PRs a `dev` → ahora aceptados desde **cualquier rama**, incluidos forks externos.

Permite contribuciones de la comunidad al repo público manteniendo la fortaleza de `main`.

## Test plan

- [ ] enforce-branch-flow verde (valida PR local → dev)