### PR TITLE
ci(security): promote — environment production + PRs externos a dev

### DIFF
--- a/.github/workflows/enforce-branch-flow.yml
+++ b/.github/workflows/enforce-branch-flow.yml
@@ -1,6 +1,7 @@
 name: Enforce branch flow
 
-# Flow: local -> dev (PR) -> main (PR)
+# Flow interno: local -> dev (PR) -> main (PR)
+# Externos: fork -> PR a dev (cualquier rama del fork) -> dev -> main (por mantenedor)
 on:
   pull_request:
     branches: [main, dev]
@@ -24,13 +25,9 @@ jobs:
           fi
           echo "OK: PR to main comes from dev."
 
-      - name: PRs to dev only from local
+      - name: PRs to dev are welcome from any branch
         if: github.base_ref == 'dev'
         run: |
-          if [ "${{ github.head_ref }}" != "local" ]; then
-            echo "ERROR: PRs to dev must come ONLY from 'local'."
-            echo "Source branch: ${{ github.head_ref }}"
-            echo "Correct flow: local -> dev (PR) -> main (PR)"
-            exit 1
-          fi
-          echo "OK: PR to dev comes from local."
+          echo "OK: PR to dev accepted from '${{ github.head_ref }}'."
+          echo "Contributors (incluidos forks externos) pueden abrir PRs a dev."
+          echo "Los mantenedores revisan y deciden que se mergea."

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
 

--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
 


### PR DESCRIPTION
## Cambios acumulados

- npm-publish.yml + pip-publish.yml: environment `production` con required reviewers (rrestevez-dell, mundowise) y branch policy solo main.
- enforce-branch-flow.yml: PRs a dev abiertos a cualquier rama (incluidos forks); PRs a main siguen restringidos a head=dev.

## Justificación

Endurece publish (cualquier write necesita reviewer) y a la vez abre dev a contribuciones externas. Coherente con repo público + flujo cuatro-ojos para producción.

## Test plan

- [ ] enforce-branch-flow verde (valida PR dev → main)