### PR TITLE
chore(gitignore): excluir .delixon.docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ coverage/
 
 # Documentacion personal del owner (planes, flujos internos)
 .delidocs/
+.delixon.docs/


### PR DESCRIPTION
Promueve a main la exclusion de .delixon.docs/ del .gitignore. Alinea con la convencion del repo privado donde la documentacion personal del owner no se versiona.