### PR TITLE
ci(npm-publish): switch a OIDC trusted publishing + provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
+      # `id-token: write` habilita OIDC: el job firma un JWT con la identidad
+      # de este workflow y npm lo valida contra el "Trusted Publisher"
+      # configurado en https://www.npmjs.com/package/@delixon/nexenv/access
+      # (delixon-labs/delixon-nexenv + npm-publish.yml + environment production).
+      # Asi publicamos sin tokens, sin OTP y sin secrets que rotar.
+      id-token: write
       contents: read
 
     steps:
@@ -30,6 +36,7 @@ jobs:
 
       - name: Publish @delixon/nexenv
         working-directory: npm/cli
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # --provenance agrega un attestation firmado al paquete: los usuarios
+        # ven en npm que el .tgz fue compilado por este workflow exacto desde
+        # este repo, no inyectado por un atacante con un token filtrado.
+        run: npm publish --access public --provenance


### PR DESCRIPTION
Reemplaza autenticacion por token (NPM_TOKEN secret) por OIDC. El Trusted Publisher ya esta configurado en npmjs.com para este repo + workflow + environment production. Agrega --provenance asi cada paquete publicado lleva attestation firmado verificable por usuarios en npm.

Despues de mergear, vienen 3 limpiezas manuales en npmjs.com (que el owner hace tras validar):
1. Cambiar 'Publishing access' a 'disallow tokens (recommended)'.
2. Borrar el secret NPM_TOKEN del repo en GitHub.
3. Borrar el token granular delixon-deploy-ci en npm.

Deja la publicacion sin secrets que rotar y mas segura.