### PR TITLE
ci(npm-publish): switch a OIDC trusted publishing + provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
+      # `id-token: write` habilita OIDC: el job firma un JWT con la identidad
+      # de este workflow y npm lo valida contra el "Trusted Publisher"
+      # configurado en https://www.npmjs.com/package/@delixon/nexenv/access
+      # (delixon-labs/delixon-nexenv + npm-publish.yml + environment production).
+      # Asi publicamos sin tokens, sin OTP y sin secrets que rotar.
+      id-token: write
       contents: read
 
     steps:
@@ -30,6 +36,7 @@ jobs:
 
       - name: Publish @delixon/nexenv
         working-directory: npm/cli
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # --provenance agrega un attestation firmado al paquete: los usuarios
+        # ven en npm que el .tgz fue compilado por este workflow exacto desde
+        # este repo, no inyectado por un atacante con un token filtrado.
+        run: npm publish --access public --provenance


### PR DESCRIPTION
Promueve a main el switch de NPM_TOKEN -> OIDC. Tras el merge:

1. (Yo) disparo publish v1.1.1 de prueba: debe fallar 403 already-published, lo que CONFIRMA que OIDC auth funciona (si OIDC fallara, fallaria con 401/auth antes del 403).
2. (Vos manual en npmjs.com) cambiar Publishing access a 'disallow tokens'.
3. (Vos manual en GitHub) borrar secret NPM_TOKEN.
4. (Vos manual en npmjs.com) borrar token granular delixon-deploy-ci.

Cero tokens que rotar de aqui en adelante.