### PR TITLE
fix(npm-publish): upgrade npm a latest para OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,13 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # OIDC trusted publishing requiere npm >= 11.5.1. La npm que viene con
+      # Node 22 (10.x) ignora el OIDC token y trata de autenticar con el
+      # placeholder vacio del .npmrc, fallando con 404. Forzamos npm latest
+      # para que el flujo OIDC se complete correctamente.
+      - name: Upgrade npm to support OIDC
+        run: npm install -g npm@latest
+
       - name: Update version
         working-directory: npm/cli
         run: npm version ${{ github.event.inputs.version }} --no-git-tag-version


### PR DESCRIPTION
Promueve el hotfix del PR #169. Tras el merge, re-corremos el test OIDC. Si pasa (debe fallar con 403 'already published' lo cual confirma OIDC auth OK), el usuario hace los 3 pasos manuales de cleanup (disallow tokens, borrar secret NPM_TOKEN, borrar token granular).