### PR TITLE
docs: changelog entry for v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Core source code moved to a private repository (`delixon-labs/nexenv-core`). Installation wrappers (npm, pip) and documentation remain public in this repository. This is a repository-organization change, not a license change — Nexenv remains source-available under FSL-1.1-ALv2 and each version still converts to Apache 2.0 two years after release. See [CONTRIBUTING.md](CONTRIBUTING.md) for the updated contribution flow.
 
+## [1.1.2] — 2026-04-30
+
+### Fixed
+
+- **Windows GUI: console window flickers eliminated** on actions that internally spawn subprocesses (folder scan, health checks, `git status`, `docker info`, processes list, "Open in editor", etc.). All non-interactive subprocess calls now use `CREATE_NO_WINDOW` on Windows.
+- **CLI shell**: `Home`, `End` and `Delete` keys now work consistently on all Windows terminals (PowerShell, Git Bash, Windows Terminal). `/clear` redraws the welcome banner and project intro instead of leaving an empty screen. `/help` no longer duplicates content when the terminal is too short to fit the help block — switched to in-place rendering with internal scroll (`PgUp` / `PgDn` / `↑↓` / `Home` / `End`), preserving the main shell scrollback.
+
+### Changed
+
+- **Default language is now English** on first install. Existing users keep their previously selected language (no migration needed).
+- The static CLI help (`nexenv --help`) and the auto-generated `nexenv.yaml` manifest content are now in English regardless of UI language.
+
+### Added
+
+- Mixed local/CI release flow: `release.yml` accepts `workflow_dispatch` with per-platform inputs (`windows` / `linux` / `macos`); `scripts/build-release.mjs` (in `delixon-labs/nexenv-core`) builds and uploads native bundles from the host OS, saving CI minutes.
+
 ## [1.0.0] — 2026-04-21
 
 ### Added


### PR DESCRIPTION
Adds the changelog entry for v1.1.2 covering the GUI console flicker fix, CLI shell keybindings, /clear and /help improvements, default language change to English, and the mixed local/CI release flow.