### PR TITLE
ci(publish): auto-bump commit a local branch tras publish exitoso

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,12 +17,25 @@ jobs:
       # configurado en https://www.npmjs.com/package/@delixon/nexenv/access
       # (delixon-labs/delixon-nexenv + npm-publish.yml + environment production).
       # Asi publicamos sin tokens, sin OTP y sin secrets que rotar.
+      #
+      # `contents: write` para hacer commit + push del bump al repo tras
+      # publish exitoso (ver step "Commit version bump"). Asi el package.json
+      # queda alineado con la version publicada en npm.
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # ref: local porque main esta protegida (require PR + enforce
+          # admins) y el bot no puede pushear directo. local es la rama
+          # de trabajo, sin restricciones de PR. El owner promueve manual
+          # local -> dev -> main siguiendo el flow estandar del repo.
+          ref: local
+          # fetch-depth: 0 para que el push funcione (con depth=1 el HEAD
+          # queda detached y no permite push).
+          fetch-depth: 0
 
       - name: Setup Node.js
         # Node 24 (LTS) viene con npm >= 11, requerido para OIDC trusted
@@ -45,3 +58,31 @@ jobs:
         # ven en npm que el .tgz fue compilado por este workflow exacto desde
         # este repo, no inyectado por un atacante con un token filtrado.
         run: npm publish --access public --provenance
+
+      - name: Commit version bump back to local branch
+        # Si la publicacion fue exitosa, commiteamos el bump del package.json
+        # (modificado por `npm version` arriba) a la rama `local`. El owner
+        # promueve manual local -> dev -> main siguiendo el flow estandar.
+        #
+        # Si la publicacion fallo, este step no corre por el default
+        # `if: success()`. El bump nunca queda en el repo apuntando a una
+        # version que no se publico realmente en npm.
+        #
+        # Sobre la rama destino: `main` esta protegida con require PR y
+        # enforce_admins, asi que ni el bot ni los admins pueden pushear
+        # directo. `local` es la rama de trabajo sin esa restriccion. El
+        # commit del bot queda como "checkpoint pendiente de promocion" en
+        # local hasta el siguiente ciclo de release.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add npm/cli/package.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit (package.json already at requested version)."
+            exit 0
+          fi
+          git commit -m "chore(npm): bump @delixon/nexenv to ${{ github.event.inputs.version }} (auto)"
+          # Pull con rebase por si hubo otros pushes a local mientras el job
+          # corria (raro pero posible).
+          git pull --rebase origin local
+          git push origin local

--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -12,11 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
-      contents: read
+      # `contents: write` para hacer commit + push del bump al repo tras
+      # publish exitoso (ver step "Commit version bump"). Asi el
+      # pyproject.toml queda alineado con la version publicada en PyPI.
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # ref: local porque main esta protegida (require PR + enforce
+          # admins) y el bot no puede pushear directo. local es la rama
+          # de trabajo, sin restricciones. El owner promueve manual
+          # local -> dev -> main siguiendo el flow estandar del repo.
+          ref: local
+          # fetch-depth: 0 para que el push funcione (con depth=1 el HEAD
+          # queda detached y no permite push).
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v6.0.0
@@ -55,3 +67,31 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: python -m twine upload dist/*
+
+      - name: Commit version bump back to local branch
+        # Si el upload a PyPI fue exitoso, commiteamos el bump del
+        # pyproject.toml a la rama `local`. El owner promueve manual
+        # local -> dev -> main siguiendo el flow estandar.
+        #
+        # Si el upload fallo, este step no corre por el default
+        # `if: success()`. El bump nunca queda en el repo apuntando a una
+        # version que no se publico realmente.
+        #
+        # Sobre la rama destino: `main` esta protegida con require PR y
+        # enforce_admins, asi que ni el bot ni los admins pueden pushear
+        # directo. `local` es la rama de trabajo sin esa restriccion. El
+        # commit del bot queda como "checkpoint pendiente de promocion" en
+        # local hasta el siguiente ciclo de release.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pip/cli/pyproject.toml
+          if git diff --cached --quiet; then
+            echo "No changes to commit (pyproject.toml already at requested version)."
+            exit 0
+          fi
+          git commit -m "chore(pip): bump nexenv to ${{ github.event.inputs.version }} (auto)"
+          # Pull con rebase por si hubo otros pushes a local mientras el job
+          # corria (raro pero posible).
+          git pull --rebase origin local
+          git push origin local


### PR DESCRIPTION
El owner pidio Camino A: ver el bump del package.json/pyproject.toml tracked en git tras cada release publicado en npm/PyPI. Antes los workflows solo modificaban los archivos en el runner (descartable) y los repos locales quedaban en 1.0.0 indefinidamente.

Mecanica:

- npm-publish.yml: tras publish OIDC exitoso, commitea npm/cli/package.json a local con git push origin local. Mensaje: 'chore(npm): bump @delixon/nexenv to X.Y.Z (auto)'.
- pip-publish.yml: idem para pip/cli/pyproject.toml.

Por que rama local y no main: main esta protegida (require PR + enforce_admins). El bot github-actions no puede pushear directo. Local es la rama de trabajo, sin restriccion. El owner promueve local -> dev -> PR a main manualmente cuando convenga (puede ser inmediato tras el release o batch al siguiente ciclo).

Sin rastros de IA en mensajes ni codigo (cumple regla del repo).