### PR TITLE
chore(wrappers): align package.json + pyproject.toml to 1.1.2

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.0.0"
+version = "1.1.2"
 description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"


### PR DESCRIPTION
Cleanup retroactivo para alinear los archivos del wrapper con la version actualmente publicada en npm (@delixon/nexenv@1.1.2) y PyPI (nexenv 1.1.2). Los releases v1.1.0, v1.1.1 y v1.1.2 se hicieron con el workflow viejo que solo bumpeaba en runtime sin commitear. Camino A (commit 037e34c) ya commitea bumps automaticamente para releases siguientes; este commit cierra el desfase historico.