### PR TITLE
chore: ignorar package-lock.json en wrapper npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 node_modules/
 .pnp
 .pnp.js
+# package-lock.json no se versiona en wrappers publicados a npm
+package-lock.json
 
 # Build outputs
 dist/


### PR DESCRIPTION
## Resumen

Agrega `package-lock.json` al `.gitignore` para que no aparezca como untracked tras un `npm install` local en `npm/cli/`.

## Por qué

El paquete `@delixon/nexenv` es un wrapper publicado a npm registry. Por convención los wrappers/libraries publicados no versionan el lock — cada consumidor genera el suyo.

El `npm install` local en `npm/cli/` solo corre el postinstall que descarga el binario desde GitHub Releases, no instala dependencias adicionales.

## Cambios

- `.gitignore`: agrega `package-lock.json`