### PR TITLE
chore: ignorar package-lock.json en wrapper npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 node_modules/
 .pnp
 .pnp.js
+# package-lock.json no se versiona en wrappers publicados a npm
+package-lock.json
 
 # Build outputs
 dist/


### PR DESCRIPTION
## Resumen

Bump del fix `.gitignore` a producción (mismo PR que #176 pero `dev → main`).

Agrega `package-lock.json` al `.gitignore` para que no aparezca como untracked tras un `npm install` local en `npm/cli/`.

## Por qué

El paquete `@delixon/nexenv` es un wrapper publicado a npm registry. Por convención los wrappers/libraries publicados no versionan el lock — cada consumidor genera el suyo.

## Atención

Este merge a `main` dispara los workflows configurados (npm-publish, pip-publish). Como NO hay cambio de versión en `package.json` ni `pyproject.toml`, los publish workflows deberían ser no-op (idempotentes) o skipearse.