### PR TITLE
fix(security): integridad SHA-256 + OIDC PyPI + sync version pip

### DIFF
--- a/.github/workflows/enforce-branch-flow.yml
+++ b/.github/workflows/enforce-branch-flow.yml
@@ -13,13 +13,19 @@ jobs:
   check-source-branch:
     name: Verify branch flow
     runs-on: ubuntu-latest
+    # head_ref se pasa via env var (no se interpola en el script):
+    # los nombres de branch son potencialmente untrusted (forks, contributors)
+    # y un nombre malicioso podria inyectar comandos en el shell.
+    env:
+      HEAD_REF: ${{ github.head_ref }}
+      BASE_REF: ${{ github.base_ref }}
     steps:
       - name: PRs to main only from dev
         if: github.base_ref == 'main'
         run: |
-          if [ "${{ github.head_ref }}" != "dev" ]; then
+          if [ "${HEAD_REF}" != "dev" ]; then
             echo "ERROR: PRs to main must come ONLY from 'dev'."
-            echo "Source branch: ${{ github.head_ref }}"
+            echo "Source branch: ${HEAD_REF}"
             echo "Correct flow: local -> dev (PR) -> main (PR)"
             exit 1
           fi
@@ -28,6 +34,6 @@ jobs:
       - name: PRs to dev are welcome from any branch
         if: github.base_ref == 'dev'
         run: |
-          echo "OK: PR to dev accepted from '${{ github.head_ref }}'."
+          echo "OK: PR to dev accepted from '${HEAD_REF}'."
           echo "Contributors (incluidos forks externos) pueden abrir PRs a dev."
           echo "Los mantenedores revisan y deciden que se mergea."

--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -12,9 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
+      # `id-token: write` habilita OIDC para Trusted Publisher de PyPI.
+      # PyPI valida la identidad del workflow contra el publisher configurado
+      # en https://pypi.org/manage/account/publishing/ (delixon-labs/
+      # delixon-nexenv + pip-publish.yml + environment production). Asi
+      # publicamos sin tokens, sin secrets que rotar y sin riesgo de filtrado.
+      #
       # `contents: write` para hacer commit + push del bump al repo tras
       # publish exitoso (ver step "Commit version bump"). Asi el
       # pyproject.toml queda alineado con la version publicada en PyPI.
+      id-token: write
       contents: write
 
     steps:
@@ -36,18 +43,25 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: python -m pip install --upgrade build twine
+        run: python -m pip install --upgrade build
 
       - name: Update version in pyproject.toml
         working-directory: pip/cli
+        # La version se pasa via env var (no interpolada en el script),
+        # asi el input nunca se inyecta literalmente en el codigo Python.
+        env:
+          NEW_VERSION: ${{ github.event.inputs.version }}
         run: |
           python - <<'PY'
-          import pathlib, re, sys
+          import os, pathlib, re, sys
+          v = os.environ["NEW_VERSION"]
+          if not re.match(r"^[0-9]+(\.[0-9]+)+([.-][a-zA-Z0-9]+)*$", v):
+              sys.exit(f"version invalida: {v!r}")
           p = pathlib.Path("pyproject.toml")
           text = p.read_text(encoding="utf-8")
           new = re.sub(
               r'^(version\s*=\s*)"[^"]*"',
-              r'\1"${{ github.event.inputs.version }}"',
+              lambda m: f'{m.group(1)}"{v}"',
               text,
               count=1,
               flags=re.MULTILINE,
@@ -61,12 +75,17 @@ jobs:
         working-directory: pip/cli
         run: python -m build
 
-      - name: Publish nexenv
-        working-directory: pip/cli
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: python -m twine upload dist/*
+      - name: Publish nexenv (OIDC Trusted Publisher)
+        # OIDC Trusted Publisher: PyPI valida la identidad del workflow via
+        # JWT firmado por GitHub. Sin tokens, sin secrets rotables. Requiere
+        # configuracion previa en pypi.org/manage/account/publishing/ con:
+        #   - Owner: delixon-labs
+        #   - Repository: delixon-nexenv
+        #   - Workflow: pip-publish.yml
+        #   - Environment: production
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.13.0
+        with:
+          packages-dir: pip/cli/dist
 
       - name: Commit version bump back to local branch
         # Si el upload a PyPI fue exitoso, commiteamos el bump del
@@ -76,12 +95,8 @@ jobs:
         # Si el upload fallo, este step no corre por el default
         # `if: success()`. El bump nunca queda en el repo apuntando a una
         # version que no se publico realmente.
-        #
-        # Sobre la rama destino: `main` esta protegida con require PR y
-        # enforce_admins, asi que ni el bot ni los admins pueden pushear
-        # directo. `local` es la rama de trabajo sin esa restriccion. El
-        # commit del bot queda como "checkpoint pendiente de promocion" en
-        # local hasta el siguiente ciclo de release.
+        env:
+          NEW_VERSION: ${{ github.event.inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -90,7 +105,7 @@ jobs:
             echo "No changes to commit (pyproject.toml already at requested version)."
             exit 0
           fi
-          git commit -m "chore(pip): bump nexenv to ${{ github.event.inputs.version }} (auto)"
+          git commit -m "chore(pip): bump nexenv to ${NEW_VERSION} (auto)"
           # Pull con rebase por si hubo otros pushes a local mientras el job
           # corria (raro pero posible).
           git pull --rebase origin local

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We provide security updates for the latest stable release of Nexenv.
 
 | Version | Supported |
 |---------|-----------|
-| 1.0.x   | ✅ Yes    |
-| < 1.0.0 | ❌ No     |
+| 1.1.x   | ✅ Yes    |
+| < 1.1.0 | ❌ No     |
 
 ## Reporting a vulnerability
 
@@ -71,4 +71,4 @@ We aim for **90 days** from report to public disclosure, with flexibility depend
 
 ---
 
-*Last updated: 2026-04-21*
+*Last updated: 2026-05-04*

--- a/npm/cli/scripts/postinstall.js
+++ b/npm/cli/scripts/postinstall.js
@@ -1,7 +1,15 @@
 /* eslint-env node */
 const { platform, arch } = process;
 const https = require("https");
-const { createWriteStream, chmodSync, existsSync, mkdirSync, unlinkSync } = require("fs");
+const crypto = require("crypto");
+const {
+  createWriteStream,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+} = require("fs");
 const { join } = require("path");
 
 const ASSET_MAP = {
@@ -26,7 +34,9 @@ if (process.env.NEXENV_SKIP_POSTINSTALL === "1") {
 
 const pkg = require("../package.json");
 const version = pkg.version;
-const url = `https://github.com/delixon-labs/delixon-nexenv/releases/download/v${version}/${asset}`;
+const releaseBase = `https://github.com/delixon-labs/delixon-nexenv/releases/download/v${version}`;
+const binaryUrl = `${releaseBase}/${asset}`;
+const checksumsUrl = `${releaseBase}/SHA256SUMS`;
 const binaryName = platform === "win32" ? "nexenv.exe" : "nexenv";
 const binDir = join(__dirname, "..", "bin");
 const destPath = join(binDir, binaryName);
@@ -66,16 +76,92 @@ function download(u, dest, maxRedirects) {
   });
 }
 
-console.log(`Nexenv: descargando binario v${version} para ${key}...`);
-download(url, destPath, 5)
-  .then(() => {
-    if (platform !== "win32") chmodSync(destPath, 0o755);
-    console.log(`Nexenv: binario instalado en ${destPath}`);
-  })
-  .catch((err) => {
-    console.error(`Nexenv: error descargando el binario: ${err.message}`);
-    console.error(`URL intentada: ${url}`);
-    console.error("Descarga manual: https://github.com/delixon-labs/delixon-nexenv/releases");
-    console.error("Asigna NEXENV_SKIP_POSTINSTALL=1 si estas en un entorno sin red.");
-    process.exit(1);
+// Descarga texto plano (para SHA256SUMS). Devuelve null si 404 — el caller
+// decide si es fatal o backward-compat con warning.
+function fetchText(u, maxRedirects) {
+  return new Promise((resolve, reject) => {
+    function attempt(current, remaining) {
+      if (remaining < 0) return reject(new Error("demasiados redirects"));
+      https
+        .get(current, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            attempt(res.headers.location, remaining - 1);
+            return;
+          }
+          if (res.statusCode === 404) return resolve(null);
+          if (res.statusCode !== 200) {
+            return reject(new Error(`HTTP ${res.statusCode} al descargar ${current}`));
+          }
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+          res.on("error", reject);
+        })
+        .on("error", reject);
+    }
+    attempt(u, maxRedirects);
   });
+}
+
+// Parsea formato GNU coreutils sha256sum: cada linea "<sha256>  <filename>".
+// Tolera "<sha256> *<filename>" (modo binario) y CRLF.
+function parseSha256Sums(text) {
+  const map = {};
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([a-f0-9]{64})\s+\*?(.+)$/i);
+    if (m) map[m[2].trim()] = m[1].toLowerCase();
+  }
+  return map;
+}
+
+function sha256OfFile(path) {
+  const h = crypto.createHash("sha256");
+  h.update(readFileSync(path));
+  return h.digest("hex");
+}
+
+async function main() {
+  console.log(`Nexenv: descargando binario v${version} para ${key}...`);
+  await download(binaryUrl, destPath, 5);
+
+  // Integridad: bajar SHA256SUMS y verificar. Si falta el asset (releases
+  // antiguas pre-checksums), warning + continuar (forward-compat).
+  console.log("Nexenv: verificando integridad (SHA-256)...");
+  const sumsText = await fetchText(checksumsUrl, 5);
+  if (!sumsText) {
+    console.warn(
+      `Nexenv: WARNING — el release v${version} no incluye SHA256SUMS.\n` +
+      "  El binario fue descargado por HTTPS pero NO se verifico integridad.\n" +
+      "  A partir de la proxima version los releases incluiran SHA256SUMS y\n" +
+      "  esta verificacion sera obligatoria.",
+    );
+  } else {
+    const sums = parseSha256Sums(sumsText);
+    const expected = sums[asset];
+    if (!expected) {
+      try { unlinkSync(destPath); } catch { /* ignore */ }
+      throw new Error(`SHA256SUMS no contiene entrada para ${asset}`);
+    }
+    const actual = sha256OfFile(destPath);
+    if (actual !== expected) {
+      try { unlinkSync(destPath); } catch { /* ignore */ }
+      throw new Error(
+        `checksum mismatch para ${asset}\n  esperado: ${expected}\n  obtenido: ${actual}`,
+      );
+    }
+    console.log(`Nexenv: integridad OK (sha256: ${expected.slice(0, 16)}...)`);
+  }
+
+  if (platform !== "win32") chmodSync(destPath, 0o755);
+  console.log(`Nexenv: binario instalado en ${destPath}`);
+}
+
+main().catch((err) => {
+  console.error(`Nexenv: error en postinstall: ${err.message}`);
+  console.error(`URL del binario: ${binaryUrl}`);
+  console.error("Descarga manual: https://github.com/delixon-labs/delixon-nexenv/releases");
+  console.error("Asigna NEXENV_SKIP_POSTINSTALL=1 si estas en un entorno sin red.");
+  process.exit(1);
+});

--- a/pip/cli/nexenv/__init__.py
+++ b/pip/cli/nexenv/__init__.py
@@ -1,3 +1,9 @@
 """Nexenv — Workspace manager for developers."""
 
-__version__ = "0.0.1"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("nexenv")
+except PackageNotFoundError:  # paquete no instalado (modo dev sin install)
+    __version__ = "0.0.0"

--- a/pip/cli/nexenv/cli.py
+++ b/pip/cli/nexenv/cli.py
@@ -1,13 +1,29 @@
 """Nexenv CLI wrapper — downloads and executes the native binary."""
 
+import hashlib
 import os
 import platform
+import re
 import subprocess
 import sys
+import time
+import urllib.error
 import urllib.request
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
-__version__ = "1.0.0"
+
+def _resolve_version() -> str:
+    """Lee la version del package metadata. Cae a 0.0.0 solo si el package
+    no esta instalado (modo dev sin pip install -e)."""
+    try:
+        return _pkg_version("nexenv")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__ = _resolve_version()
 
 PLATFORM_MAP = {
     ("Windows", "AMD64"): "nexenv-cli-win32-x64.exe",
@@ -17,7 +33,10 @@ PLATFORM_MAP = {
     ("Darwin", "x86_64"): "nexenv-cli-darwin-x64",
 }
 
-RELEASE_URL = "https://github.com/delixon-labs/delixon-nexenv/releases/download/v{version}/{binary}"
+RELEASE_BASE = "https://github.com/delixon-labs/delixon-nexenv/releases/download/v{version}"
+DOWNLOAD_TIMEOUT_S = 60
+DOWNLOAD_MAX_RETRIES = 3
+DOWNLOAD_RETRY_DELAY_S = 2
 
 
 def get_bin_dir() -> Path:
@@ -44,27 +63,102 @@ def get_binary_name() -> str:
 
 def get_binary_path() -> Path:
     """Get the full path to the native binary."""
-    binary_name = get_binary_name()
-    # Use simple name for the local binary
+    get_binary_name()
     local_name = "nexenv.exe" if platform.system() == "Windows" else "nexenv"
     return get_bin_dir() / local_name
 
 
+def _http_get(url: str, *, timeout: int = DOWNLOAD_TIMEOUT_S):
+    """GET con retry y timeout. Devuelve bytes, o None si 404."""
+    last_err = None
+    for attempt in range(1, DOWNLOAD_MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as r:
+                return r.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            last_err = e
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_err = e
+        if attempt < DOWNLOAD_MAX_RETRIES:
+            time.sleep(DOWNLOAD_RETRY_DELAY_S * attempt)
+    raise RuntimeError(f"fallo al descargar {url}: {last_err}")
+
+
+def _parse_sha256sums(text: str) -> dict:
+    """Parsea formato GNU coreutils sha256sum: '<sha>  <filename>'."""
+    result = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([a-fA-F0-9]{64})\s+\*?(.+)$", line)
+        if m:
+            result[m.group(2).strip()] = m.group(1).lower()
+    return result
+
+
 def download_binary(version: str) -> Path:
-    """Download the native binary from GitHub Releases."""
+    """Download the native binary from GitHub Releases (with SHA-256 verify)."""
     binary_name = get_binary_name()
-    url = RELEASE_URL.format(version=version, binary=binary_name)
+    base = RELEASE_BASE.format(version=version)
+    binary_url = f"{base}/{binary_name}"
+    sums_url = f"{base}/SHA256SUMS"
     dest = get_binary_path()
 
     print(f"Nexenv: descargando binario v{version}...")
     try:
-        urllib.request.urlretrieve(url, dest)
+        data = _http_get(binary_url)
     except Exception as e:
         print(f"Nexenv: error descargando binario: {e}", file=sys.stderr)
-        print(f"URL: {url}", file=sys.stderr)
+        print(f"URL: {binary_url}", file=sys.stderr)
+        sys.exit(1)
+    if data is None:
+        print(f"Nexenv: el release v{version} no contiene {binary_name}", file=sys.stderr)
+        print(f"URL: {binary_url}", file=sys.stderr)
         sys.exit(1)
 
-    # Make executable on Unix
+    # Verificacion SHA-256. Si SHA256SUMS no existe (releases pre-checksums)
+    # warning y continuar — forward-compat, en proximas versiones obligatorio.
+    print("Nexenv: verificando integridad (SHA-256)...")
+    try:
+        sums_raw = _http_get(sums_url)
+    except Exception as e:
+        print(f"Nexenv: error descargando SHA256SUMS: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if sums_raw is None:
+        print(
+            f"Nexenv: WARNING — el release v{version} no incluye SHA256SUMS.\n"
+            "  El binario fue descargado por HTTPS pero NO se verifico integridad.\n"
+            "  A partir de la proxima version los releases incluiran SHA256SUMS\n"
+            "  y esta verificacion sera obligatoria.",
+            file=sys.stderr,
+        )
+    else:
+        sums = _parse_sha256sums(sums_raw.decode("utf-8"))
+        expected = sums.get(binary_name)
+        if not expected:
+            print(
+                f"Nexenv: SHA256SUMS no contiene entrada para {binary_name}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected:
+            print(
+                f"Nexenv: checksum mismatch para {binary_name}\n"
+                f"  esperado: {expected}\n"
+                f"  obtenido: {actual}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Nexenv: integridad OK (sha256: {expected[:16]}...)")
+
+    # Escribir solo despues de verificar (no dejar binarios sin validar
+    # en disco si SHA256SUMS fallo).
+    dest.write_bytes(data)
     if platform.system() != "Windows":
         os.chmod(dest, 0o755)
 
@@ -76,17 +170,21 @@ def main():
     """Entry point — run the native binary or download it first."""
     binary = get_binary_path()
 
-    # Download if not exists
     if not binary.exists():
         binary = download_binary(__version__)
 
-    # Execute the native binary with all arguments
     try:
-        result = subprocess.run([str(binary)] + sys.argv[1:])
+        result = subprocess.run([str(binary), *sys.argv[1:]])  # noqa: S603
         sys.exit(result.returncode)
     except FileNotFoundError:
-        print("Nexenv: binario no encontrado. Reinstala con: pip install --force-reinstall nexenv", file=sys.stderr)
+        print(
+            "Nexenv: binario no encontrado. Reinstala con: pip install --force-reinstall nexenv",
+            file=sys.stderr,
+        )
         sys.exit(1)
     except PermissionError:
-        print("Nexenv: sin permisos de ejecucion. Reinstala con: pip install --force-reinstall nexenv", file=sys.stderr)
+        print(
+            "Nexenv: sin permisos de ejecucion. Reinstala con: pip install --force-reinstall nexenv",
+            file=sys.stderr,
+        )
         sys.exit(1)


### PR DESCRIPTION
## Resumen

Hardening de la cadena de distribucion del wrapper publico, basado en auditoria 2026-05-04.

## Cambios criticos

- **C-1, C-2** — npm postinstall y pip cli verifican **SHA-256** del binario contra `SHA256SUMS` del GH Release. Forward-compat con warning si el release no lo incluye; obligatorio desde la proxima version.
- **C-3** — pip cli lee la version del package metadata (`importlib.metadata`). Antes el `__version__` estaba hardcodeado a 1.0.0 y la URL de descarga no coincidia con lo publicado en PyPI.
- **C-4** — `pip-publish` migra a **OIDC Trusted Publisher** (`pypa/gh-action-pypi-publish`) en vez de `TWINE_PASSWORD` con secret. Sin tokens rotables.

## Cambios warning

- **W-5** SECURITY.md: tabla 1.1.x.
- **W-6** `pip-publish`: `NEW_VERSION` via env var en lugar de interpolar dentro de heredoc Python.
- **W-10** pip cli `download_binary`: retry (3 intentos) + timeout (60s).
- **W-13** (extra detectado por actionlint) `enforce-branch-flow`: `head_ref`/`base_ref` via env var (input untrusted).

## Pendiente fuera de codigo

- `pypi.org`: configurar Trusted Publisher antes del primer release con esta version (Owner: `delixon-labs`, Repo: `delixon-nexenv`, Workflow: `pip-publish.yml`, Environment: `production`).
- `nexenv-core`: agregar al workflow de release la generacion y subida de `SHA256SUMS` como asset.

## Compatibilidad

- v1.1.2 publicada en npm/PyPI no se ve afectada (estos fixes aplican a futuras instalaciones tras el proximo release).
- Sin cambio de version del wrapper en este PR.