### PR TITLE
chore: bump @delixon/nexenv@1.2.0 + nexenv@1.2.0 (auto from publish)

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.1.2"
+version = "1.2.0"
 description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"


### PR DESCRIPTION
Promociona a dev los commits que los workflows publish hicieron tras la publicación exitosa de v1.2.0:

- 92749be: bump @delixon/nexenv en npm/cli/package.json
- be1c89e: bump nexenv en pip/cli/pyproject.toml

Ambos son commits del bot de GitHub Actions, sin cambios funcionales — solo versionado.