### PR TITLE
chore: release v1.2.0 (npm + pip bumps)

### DIFF
--- a/.github/workflows/enforce-branch-flow.yml
+++ b/.github/workflows/enforce-branch-flow.yml
@@ -1,6 +1,8 @@
 name: Enforce branch flow
 
 # Flow interno: local -> dev (PR) -> main (PR)
+# Excepcion: ramas release/* pueden ir directo a main (cherry-picks firmados,
+# hotfixes coordinados con nexenv-core, sincronizaciones puntuales).
 # Externos: fork -> PR a dev (cualquier rama del fork) -> dev -> main (por mantenedor)
 on:
   pull_request:
@@ -20,16 +22,21 @@ jobs:
       HEAD_REF: ${{ github.head_ref }}
       BASE_REF: ${{ github.base_ref }}
     steps:
-      - name: PRs to main only from dev
+      - name: PRs to main only from dev or release/*
         if: github.base_ref == 'main'
         run: |
-          if [ "${HEAD_REF}" != "dev" ]; then
-            echo "ERROR: PRs to main must come ONLY from 'dev'."
-            echo "Source branch: ${HEAD_REF}"
-            echo "Correct flow: local -> dev (PR) -> main (PR)"
-            exit 1
-          fi
-          echo "OK: PR to main comes from dev."
+          case "${HEAD_REF}" in
+            dev|release/*)
+              echo "OK: PR to main comes from '${HEAD_REF}'."
+              ;;
+            *)
+              echo "ERROR: PRs to main must come from 'dev' or 'release/*'."
+              echo "Source branch: ${HEAD_REF}"
+              echo "Correct flow: local -> dev (PR) -> main (PR)"
+              echo "Excepcion: release/* permitido para cherry-picks firmados y hotfixes."
+              exit 1
+              ;;
+          esac
 
       - name: PRs to dev are welcome from any branch
         if: github.base_ref == 'dev'

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.1.2"
+version = "1.2.0"
 description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"


### PR DESCRIPTION
## Resumen

Sube las versiones de los wrappers a v1.2.0 (alineado con el release de nexenv-core).

- `package.json`: 1.1.2 -> 1.2.0
- `pyproject.toml`: 1.1.2 -> 1.2.0

## Origen de los commits

Cherry-pick de los bumps automaticos generados por los workflows `npm-publish.yml` y `pip-publish.yml` tras la publicacion de v1.2.0 en npm y PyPI. Los originales del bot llegaron sin firma; estos cherry-picks estan firmados con la SSH key del owner para cumplir `required_signatures` de main.

## Test plan

- [x] Verificacion local de firmas (ED25519 SSH)
- [x] CodeQL workflows passing en dev
- [x] npm `@delixon/nexenv@1.2.0` ya publicado
- [x] PyPI `nexenv==1.2.0` ya publicado