### PR TITLE
fix publish: paso de version idempotente

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,7 +50,18 @@ jobs:
 
       - name: Update version
         working-directory: npm/cli
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        # Idempotente: si package.json ya esta en la version pedida (el owner
+        # ya bumpeo y promociono a local), NO se ejecuta `npm version` (que
+        # falla con "Version not changed"). Se publica igual.
+        env:
+          NEW_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" = "$NEW_VERSION" ]; then
+            echo "package.json ya en $NEW_VERSION; no se cambia."
+          else
+            npm version "$NEW_VERSION" --no-git-tag-version
+          fi
 
       - name: Publish @delixon/nexenv
         working-directory: npm/cli

--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -59,16 +59,19 @@ jobs:
               sys.exit(f"version invalida: {v!r}")
           p = pathlib.Path("pyproject.toml")
           text = p.read_text(encoding="utf-8")
-          new = re.sub(
-              r'^(version\s*=\s*)"[^"]*"',
-              lambda m: f'{m.group(1)}"{v}"',
-              text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if new == text:
+          pat = re.compile(r'^(version\s*=\s*)"([^"]*)"', flags=re.MULTILINE)
+          m = pat.search(text)
+          # Distinguir "campo ausente" (error real) de "ya en la version
+          # pedida" (idempotente: no-op y se publica igual).
+          if not m:
               sys.exit("version field not found in pyproject.toml")
-          p.write_text(new, encoding="utf-8")
+          if m.group(2) == v:
+              print(f"pyproject.toml ya en {v}; no se cambia.")
+          else:
+              p.write_text(
+                  pat.sub(lambda mm: f'{mm.group(1)}"{v}"', text, count=1),
+                  encoding="utf-8",
+              )
           PY
 
       - name: Build sdist and wheel


### PR DESCRIPTION
npm/pip publish fallaban con la version ya bumpeada (Version not changed / version field not found). Hechos idempotentes: si ya esta en la version pedida, no-op y se publica igual.