### PR TITLE
Release wrapper 1.3.1

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.3.0"
+version = "1.3.1"
 description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"


### PR DESCRIPTION
Bump del wrapper npm (`@delixon/nexenv`) y pip (`delixon-nexenv`)
a 1.3.1. Alinea con el binario v1.3.1 publicado por nexenv-core
(release.yml dispara Windows + macOS automaticos, Linux por dispatch).

Tras mergear se disparan los workflows `npm-publish.yml` y
`pip-publish.yml` con `version=1.3.1` para publicar en npm y PyPI.