### PR TITLE
release(wrapper): bump 1.4.0 (npm + pip auto)

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.3.1"
+version = "1.4.0"
 description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"


### PR DESCRIPTION
Promueve a dev los 2 commits chore del bot tras publish 1.4.0:
- c3569df chore(npm): bump @delixon/nexenv to 1.4.0 (auto)
- b85f5d4 chore(pip): bump nexenv to 1.4.0 (auto)

Cierra el ciclo 1.4.0 alineando local -> dev -> main.