### PR TITLE
Release 1.5.2 (wrappers npm/pip)

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delixon/nexenv",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Desktop + CLI. Source-available (FSL-1.1-ALv2).",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Delixon Labs <hello@delixon.dev> (https://delixon.dev)",

--- a/pip/cli/pyproject.toml
+++ b/pip/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nexenv"
-version = "1.5.1"
+version = "1.5.2"
 description = "Per-project development environment manager. Detects stack, isolates variables, opens projects ready to work. Source-available (FSL-1.1-ALv2)."
 readme = "README.md"
 license = "LicenseRef-FSL-1.1-ALv2"


### PR DESCRIPTION
Bump @delixon/nexenv (npm) y nexenv (PyPI) a 1.5.2. Publicado via OIDC tras el Release v1.5.2. Alinea main.